### PR TITLE
Import historyState for sharing

### DIFF
--- a/share-manager.js
+++ b/share-manager.js
@@ -1,11 +1,12 @@
 // share-manager.js - Fixed sharing functionality
 
 import { encodeState, decodeState, toast } from './utils.js';
-import { 
-  buildProject, 
+import {
+  buildProject,
   applyProject,
   setIsViewer,
-  setCurrentProjectId // <-- ensure this exists (we added it in state-manager)
+  setCurrentProjectId,
+  historyState // <-- ensure this exists (we added it in state-manager)
 } from './state-manager.js';
 
 // Prefer a canonical viewer origin in production so shared links always open the public viewer.


### PR DESCRIPTION
## Summary
- Import `historyState` from `state-manager` to prevent undefined reference when locking history in share flows.

## Testing
- `node -e "import('./share-manager.js').then(() => console.log('Imported OK')).catch(e => console.error('Import error', e))" --input-type=module` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bcd781ec832aac28c29f6a29dbf5