### PR TITLE
Fix transform handler cleanup

### DIFF
--- a/drag-handlers.js
+++ b/drag-handlers.js
@@ -8,12 +8,17 @@ export class DragHandlersManager {
   constructor() {
     this.isInitialized = false;
     this.dragState = null;
-    
+
     // Bind methods to preserve context
     this.handlePointerDown = this.handlePointerDown.bind(this);
     this.handlePointerMove = this.handlePointerMove.bind(this);
     this.handlePointerUp = this.handlePointerUp.bind(this);
     this.handleWorkClick = this.handleWorkClick.bind(this);
+
+    // Store bound transform handlers for add/remove operations
+    this.onTransformPointerDown = this.handleTransformPointerDown.bind(this);
+    this.onTransformPointerMove = this.handleTransformPointerMove.bind(this);
+    this.onTransformPointerUp = this.handleTransformPointerUp.bind(this);
   }
 
   /**
@@ -64,9 +69,9 @@ export class DragHandlersManager {
       return;
     }
 
-    bgBox.addEventListener('pointerdown', this.handleTransformPointerDown.bind(this));
-    bgBox.addEventListener('pointermove', this.handleTransformPointerMove.bind(this));
-    bgBox.addEventListener('pointerup', this.handleTransformPointerUp.bind(this));
+    bgBox.addEventListener('pointerdown', this.onTransformPointerDown);
+    bgBox.addEventListener('pointermove', this.onTransformPointerMove);
+    bgBox.addEventListener('pointerup', this.onTransformPointerUp);
   }
 
   /**
@@ -458,9 +463,9 @@ export class DragHandlersManager {
 
     const bgBox = document.getElementById('bgBox');
     if (bgBox) {
-      bgBox.removeEventListener('pointerdown', this.handleTransformPointerDown);
-      bgBox.removeEventListener('pointermove', this.handleTransformPointerMove);
-      bgBox.removeEventListener('pointerup', this.handleTransformPointerUp);
+      bgBox.removeEventListener('pointerdown', this.onTransformPointerDown);
+      bgBox.removeEventListener('pointermove', this.onTransformPointerMove);
+      bgBox.removeEventListener('pointerup', this.onTransformPointerUp);
     }
     
     // Reset state

--- a/drag-handlers.test.mjs
+++ b/drag-handlers.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert';
+import { DragHandlersManager } from './drag-handlers.js';
+
+class MockElement {
+  constructor() {
+    this.listeners = {};
+  }
+  addEventListener(type, handler) {
+    if (!this.listeners[type]) this.listeners[type] = new Set();
+    this.listeners[type].add(handler);
+  }
+  removeEventListener(type, handler) {
+    this.listeners[type]?.delete(handler);
+  }
+  listenerCount(type) {
+    return this.listeners[type]?.size ?? 0;
+  }
+}
+
+const elements = {
+  work: new MockElement(),
+  bgBox: new MockElement()
+};
+
+global.document = {
+  getElementById(id) {
+    return elements[id] || null;
+  },
+  body: { classList: { contains: () => false } }
+};
+
+global.window = {};
+
+const manager = new DragHandlersManager();
+manager.initialize();
+
+// Ensure listeners are added
+assert.strictEqual(elements.work.listenerCount('pointerdown'), 1);
+assert.strictEqual(elements.work.listenerCount('pointermove'), 1);
+assert.strictEqual(elements.work.listenerCount('pointerup'), 1);
+assert.strictEqual(elements.work.listenerCount('click'), 1);
+assert.strictEqual(elements.bgBox.listenerCount('pointerdown'), 1);
+assert.strictEqual(elements.bgBox.listenerCount('pointermove'), 1);
+assert.strictEqual(elements.bgBox.listenerCount('pointerup'), 1);
+
+manager.cleanup();
+
+// All listeners should be removed
+assert.strictEqual(elements.work.listenerCount('pointerdown'), 0);
+assert.strictEqual(elements.work.listenerCount('pointermove'), 0);
+assert.strictEqual(elements.work.listenerCount('pointerup'), 0);
+assert.strictEqual(elements.work.listenerCount('click'), 0);
+assert.strictEqual(elements.bgBox.listenerCount('pointerdown'), 0);
+assert.strictEqual(elements.bgBox.listenerCount('pointermove'), 0);
+assert.strictEqual(elements.bgBox.listenerCount('pointerup'), 0);
+
+console.log('cleanup removes listeners successfully');
+


### PR DESCRIPTION
## Summary
- store bound transform handlers in constructor
- use bound handlers for adding and removing transform box events
- add test ensuring cleanup removes listeners

## Testing
- `node drag-handlers.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b8be80058c832abca8935497e0c7f7