### PR TITLE
Initialize session data before loading token

### DIFF
--- a/api-client.js
+++ b/api-client.js
@@ -17,19 +17,21 @@ class APIClient {
         baseURL = 'http://localhost:3001/api';
       }
     }
-    
+
     this.baseURL = baseURL;
-    this.token = this.loadToken();
-    this.setupInterceptors();
-    this.isRetrying = false;
-    this._debug = false;
-    
+
     // FIXED: In-memory session storage for tokens
     this._sessionData = {
       token: null,
       user: null,
       lastActivity: null
     };
+
+    // Initialize token after session data is ready
+    this.token = this.loadToken();
+    this.setupInterceptors();
+    this.isRetrying = false;
+    this._debug = false;
   }
 
   setupInterceptors() {


### PR DESCRIPTION
## Summary
- Create in-memory session storage before calling `loadToken` so the method can access `_sessionData`
- Load token and set up interceptors after session data is initialized

## Testing
- `npm test` *(fails: missing package.json)*
- `node drag-handlers.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa891934832a900e87363b9898b1