### PR TITLE
fix: guard interceptor setup for non-browser

### DIFF
--- a/api-client.js
+++ b/api-client.js
@@ -35,11 +35,19 @@ class APIClient {
   }
 
   setupInterceptors() {
-    // Store original fetch for potential restoration
-    this._originalFetch = window.fetch;
-    
-    // Could add request/response interceptors here if needed
-    this._log('API Client initialized with base URL:', this.baseURL);
+    if (typeof window !== 'undefined' && window.fetch) {
+      // Store original fetch for potential restoration in browsers
+      this._originalFetch = window.fetch;
+
+      // Could add request/response interceptors here if needed
+      this._log('API Client initialized with base URL:', this.baseURL);
+    } else {
+      // Fallback for non-browser environments (e.g., Node.js)
+      this._originalFetch = (typeof globalThis !== 'undefined' && globalThis.fetch)
+        ? globalThis.fetch
+        : undefined;
+      this._log('API Client initialized without browser environment:', this.baseURL);
+    }
   }
 
   // FIXED: In-memory token management instead of localStorage


### PR DESCRIPTION
## Summary
- guard `setupInterceptors()` from running in non-browser environments
- provide a fallback using `globalThis.fetch` when `window` is unavailable

## Testing
- `node drag-handlers.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9ab9f694c832a902012f4c33d3e66