### PR TITLE
Escape and test access error messages

### DIFF
--- a/purchased-design-manager.js
+++ b/purchased-design-manager.js
@@ -59,7 +59,7 @@ export class PurchasedDesignManager {
       
     } catch (error) {
       console.error('❌ Failed to initialize purchased design manager:', error);
-      this.showAccessError(this.escapeHtml(error.message || 'Failed to initialize'));
+      this.showAccessError(error.message || 'Failed to initialize');
       throw error;
     }
   }
@@ -578,11 +578,12 @@ export class PurchasedDesignManager {
    * Show access error (expired/invalid token)
    */
   showAccessError(message) {
+    const safeMessage = this.escapeHtml(message);
     document.body.innerHTML = `
       <div style="position: fixed; inset: 0; background: linear-gradient(135deg, #0f1a2d, #1a2332); display: flex; align-items: center; justify-content: center; padding: 2rem;">
         <div style="background: white; border-radius: 18px; padding: 3rem; max-width: 500px; text-align: center;">
           <h1 style="color: #1f2937; margin-bottom: 1rem;">Access Expired or Invalid</h1>
-          <p style="color: #6b7280; margin-bottom: 2rem;">${message}</p>
+          <p style="color: #6b7280; margin-bottom: 2rem;">${safeMessage}</p>
           <p style="color: #6b7280; font-size: 14px;">
             If you believe this is an error, please contact support with your purchase details.
           </p>

--- a/purchased-design-manager.test.mjs
+++ b/purchased-design-manager.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert';
+import { PurchasedDesignManager } from './purchased-design-manager.js';
+
+// Stub document with minimal DOM escaping capability
+function createElement(tag) {
+  return {
+    innerHTML: '',
+    set textContent(value) {
+      this.innerHTML = value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+  };
+}
+
+global.document = {
+  body: { innerHTML: '' },
+  createElement
+};
+
+global.window = {};
+
+const manager = new PurchasedDesignManager('token');
+const malicious = '<img src=x onerror="globalThis.hacked=true">';
+manager.showAccessError(malicious);
+
+// The body should contain escaped HTML, not actual <img> tags
+assert.ok(document.body.innerHTML.includes('&lt;img src=x onerror='));
+assert.ok(!document.body.innerHTML.includes('<img'));
+assert.strictEqual(globalThis.hacked, undefined);
+
+console.log('showAccessError escapes message HTML');


### PR DESCRIPTION
## Summary
- Escape access error messages inside `showAccessError`
- Remove redundant external escaping when displaying access errors
- Add unit test to ensure HTML in messages is rendered as text

## Testing
- `node utils.test.mjs`
- `node drag-handlers.test.mjs`
- `node purchased-design-manager.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9bc240674832a8c996bb0eb9bac74