### PR TITLE
Refactor slide manager to use shared time formatter

### DIFF
--- a/slide-manager.js
+++ b/slide-manager.js
@@ -7,7 +7,7 @@ import {
   saveProjectDebounced, updateUndoRedoUI
 } from './state-manager.js';
 
-import { clamp, DEFAULT_DUR } from './utils.js';
+import { clamp, DEFAULT_DUR, fmtSec } from './utils.js';
 import { buildLayersFromDOM, loadLayersIntoDOM, updateTextFadeUI } from './text-manager.js';
 import { 
   imgState, setTransforms, updateImageFadeUI 
@@ -131,10 +131,6 @@ function currentSlide() {
   const s = getSlides();
   const i = getActiveIndex();
   return s[i];
-}
-
-function fmtSec(ms) {
-  return ((ms || 0) / 1000).toFixed(1) + 's';
 }
 
 function ensureSlide(idx) {


### PR DESCRIPTION
## Summary
- remove local `fmtSec` from `slide-manager.js`
- import `fmtSec` from `utils.js` for consistent formatting

## Testing
- `node utils.test.mjs`
- `node drag-handlers.test.mjs`
- `node purchased-design-manager.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9e4018a60832aafadbb9d51ab6a5c