### PR TITLE
refactor: export class instead of instance

### DIFF
--- a/main.js
+++ b/main.js
@@ -328,4 +328,4 @@ initializeApp().catch(error => {
 
 // Export for module systems
 export { InvitationMakerApp, initializeApp };
-export default appInstance;
+export default InvitationMakerApp;


### PR DESCRIPTION
## Summary
- avoid exporting uninitialized app instance
- export InvitationMakerApp class as module default

## Testing
- `node drag-handlers.test.mjs`
- `node purchased-design-manager.test.mjs`
- `node utils.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9e5239f10832aa9f5601b05c7f066