### PR TITLE
Add tests for utilities and UI manager

### DIFF
--- a/purchased-design-manager.test.mjs
+++ b/purchased-design-manager.test.mjs
@@ -33,3 +33,10 @@ assert.ok(!document.body.innerHTML.includes('<img'));
 assert.strictEqual(globalThis.hacked, undefined);
 
 console.log('showAccessError escapes message HTML');
+
+// Directly verify escapeHtml behavior
+assert.strictEqual(
+  manager.escapeHtml('<b>bold & "quotes"</b>'),
+  '&lt;b&gt;bold &amp; &quot;quotes&quot;&lt;/b&gt;'
+);
+console.log('escapeHtml safely encodes special characters');

--- a/ui-manager.test.mjs
+++ b/ui-manager.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert';
+
+// --- Minimal DOM stubs ---
+function createStubElement(id) {
+  return {
+    id,
+    style: {},
+    classList: {
+      classes: new Set(),
+      add(c) { this.classes.add(c); },
+      remove(c) { this.classes.delete(c); },
+      contains(c) { return this.classes.has(c); },
+      toggle(c, force) {
+        if (force === undefined) {
+          if (this.classes.has(c)) { this.classes.delete(c); return false; }
+          this.classes.add(c); return true;
+        }
+        if (force) { this.classes.add(c); return true; }
+        this.classes.delete(c); return false;
+      }
+    },
+    attributes: {},
+    setAttribute(k, v) { this.attributes[k] = v; },
+    getAttribute(k) { return this.attributes[k]; },
+    textContent: '',
+    innerHTML: '',
+    disabled: false,
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+    removeEventListener() {},
+    getBoundingClientRect() { return { width: 0, height: 0 }; }
+  };
+}
+
+const elements = { body: createStubElement('body') };
+
+global.document = {
+  readyState: 'loading',
+  body: elements.body,
+  documentElement: { style: { setProperty() {} } },
+  getElementById(id) {
+    if (!elements[id]) elements[id] = createStubElement(id);
+    return elements[id];
+  },
+  querySelector(sel) {
+    if (sel.startsWith('#')) return this.getElementById(sel.slice(1));
+    return createStubElement(sel);
+  },
+  createElement(tag) { return createStubElement(tag); },
+  addEventListener() {},
+  removeEventListener() {}
+};
+
+global.window = {
+  addEventListener() {},
+  removeEventListener() {},
+  matchMedia() { return { matches: false, addEventListener() {}, removeEventListener() {} }; },
+  open() {},
+  location: { hostname: 'example.com' }
+};
+
+const ui = await import('./ui-manager.js');
+const { setMobileTopbarCollapsed, togglePanel } = ui;
+
+const body = document.body;
+const topbarToggle = document.getElementById('topbarToggle');
+const togglePanelBtn = document.getElementById('togglePanelBtn');
+const previewBtn = document.getElementById('previewBtn');
+
+// --- setMobileTopbarCollapsed ---
+setMobileTopbarCollapsed(true);
+assert.ok(body.classList.contains('mb-topbar-collapsed'));
+assert.strictEqual(topbarToggle.getAttribute('aria-expanded'), 'false');
+assert.strictEqual(topbarToggle.textContent, '▾');
+
+setMobileTopbarCollapsed(false);
+assert.ok(!body.classList.contains('mb-topbar-collapsed'));
+assert.strictEqual(topbarToggle.getAttribute('aria-expanded'), 'true');
+assert.strictEqual(topbarToggle.textContent, '▴');
+console.log('setMobileTopbarCollapsed updates DOM state');
+
+// --- togglePanel ---
+togglePanel(); // opens panel
+assert.ok(body.classList.contains('panel-open'));
+assert.strictEqual(togglePanelBtn.getAttribute('aria-expanded'), 'true');
+assert.strictEqual(previewBtn.getAttribute('aria-pressed'), 'false');
+
+togglePanel(); // closes panel
+assert.ok(!body.classList.contains('panel-open'));
+assert.strictEqual(togglePanelBtn.getAttribute('aria-expanded'), 'false');
+console.log('togglePanel opens and closes the editor panel');

--- a/utils.test.mjs
+++ b/utils.test.mjs
@@ -23,3 +23,7 @@ const decoded = decodeState(encoded);
 
 assert.strictEqual(decoded.slides[0].layers[0].text, 'こんにちは世界🌍');
 console.log('encodeState/decodeState round-trip non-ASCII text successfully');
+
+// Invalid data should throw a clear error
+assert.throws(() => decodeState('not_base64!'), /Invalid or corrupted/);
+console.log('decodeState rejects malformed input');


### PR DESCRIPTION
## Summary
- Extend utils tests to cover error handling in decodeState
- Verify PurchasedDesignManager.escapeHtml sanitizes strings
- Add UI manager tests for mobile topbar collapse and panel toggling

## Testing
- `node utils.test.mjs`
- `node purchased-design-manager.test.mjs`
- `node ui-manager.test.mjs`
- `node drag-handlers.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b9e5e61f40832a8e04da7acaf49470