### PR TITLE
Export initializeApp as default entry point

### DIFF
--- a/main.js
+++ b/main.js
@@ -328,4 +328,4 @@ initializeApp().catch(error => {
 
 // Export for module systems
 export { InvitationMakerApp, initializeApp };
-export default InvitationMakerApp;
+export default initializeApp;


### PR DESCRIPTION
## Summary
- make initializeApp the default export and keep class exports named

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e7a98e80832a9fe8a50d9eb0ed7d