### PR TITLE
Autoplay shared viewer slides with fade transitions

### DIFF
--- a/share-manager.js
+++ b/share-manager.js
@@ -162,13 +162,14 @@ export function applyViewerFromUrl() {
 
       // Ensure slides render after applying project
       if (data.slides && data.slides.length > 0) {
-        import('./slide-manager.js').then(async ({ loadSlideIntoDOM, updateSlidesUI }) => {
+        import('./slide-manager.js').then(async ({ loadSlideIntoDOM, updateSlidesUI, startPlay }) => {
           try {
             const activeIndex = Math.max(0, Math.min(data.activeIndex || 0, data.slides.length - 1));
             await loadSlideIntoDOM(data.slides[activeIndex]);
             updateSlidesUI();
 
             if (isViewer) {
+              startPlay();
               [...document.querySelectorAll('.layer')].forEach((el) =>
                 el.setAttribute('contenteditable', 'false')
               );

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -580,7 +580,7 @@ async function stepFrame(ts) {
   setRafId(rafId);
 }
 
-function startPlay() {
+export function startPlay() {
   if (getPlaying()) return;
   
   setPlaying(true);


### PR DESCRIPTION
## Summary
- Export `startPlay` from slide manager
- Auto-start playback when loading shared viewer links

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68bae5773cf4832aa734b0e74e64f764