### PR TITLE
Handle arrays and non-plain objects in deep merge

### DIFF
--- a/state-manager.js
+++ b/state-manager.js
@@ -595,15 +595,25 @@ class ApplicationStateManager {
    */
   deepMerge(target, source) {
     const result = { ...target };
-    
+
     for (const key in source) {
-      if (source[key] !== null && typeof source[key] === 'object' && !Array.isArray(source[key])) {
-        result[key] = this.deepMerge(target[key] || {}, source[key]);
+      const value = source[key];
+      if (Array.isArray(value)) {
+        // Shallow-copy arrays to avoid reference sharing
+        result[key] = [...value];
+      } else if (
+        value !== null &&
+        typeof value === 'object' &&
+        value.constructor === Object
+      ) {
+        // Recursively merge only plain objects
+        result[key] = this.deepMerge(target[key] || {}, value);
       } else {
-        result[key] = source[key];
+        // Functions, class instances, primitives, etc.
+        result[key] = value;
       }
     }
-    
+
     return result;
   }
 

--- a/state-manager.test.mjs
+++ b/state-manager.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import { stateManager } from './state-manager.js';
+
+// Create a fresh instance to avoid state pollution
+const sm = new stateManager.constructor();
+
+// --- Array merging ---
+{
+  const target = { arr: [1, 2] };
+  const source = { arr: [3, 4] };
+  const result = sm.deepMerge(target, source);
+
+  assert.deepStrictEqual(result.arr, [3, 4]);
+  assert.notStrictEqual(result.arr, source.arr, 'arrays should be shallow-copied');
+  console.log('deepMerge replaces arrays with shallow copies');
+}
+
+// --- Non-plain objects ---
+{
+  class Custom {
+    constructor(x) { this.x = x; }
+  }
+  const target = { obj: new Custom(1) };
+  const source = { obj: new Custom(2) };
+  const result = sm.deepMerge(target, source);
+
+  assert.strictEqual(result.obj, source.obj);
+  assert.notStrictEqual(result.obj, target.obj);
+  console.log('deepMerge bypasses recursion for class instances');
+}


### PR DESCRIPTION
## Summary
- Ensure deepMerge shallow-copies arrays and recurses only into plain objects
- Cover array merging and class instance handling in unit tests

## Testing
- `node drag-handlers.test.mjs`
- `node purchased-design-manager.test.mjs`
- `node ui-manager.test.mjs`
- `node utils.test.mjs`
- `node state-manager.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bae9d0f264832aa5655133a7fb4429