### PR TITLE
Add My Designs page and API method

### DIFF
--- a/api-client.js
+++ b/api-client.js
@@ -311,6 +311,10 @@ class APIClient {
   }
 
   // Project management endpoints (unchanged)
+  async getUserDesigns() {
+    return this.get('/designs');
+  }
+
   async getProjects() {
     return this.get('/projects');
   }

--- a/auth-ui-manager.js
+++ b/auth-ui-manager.js
@@ -309,6 +309,11 @@ export class AuthUIManager {
       // Could show user info in status text
       // statusText.textContent = `Welcome, ${user.name || user.email}`;
     }
+
+    const myDesignsLink = document.getElementById('myDesignsLink');
+    if (myDesignsLink) {
+      myDesignsLink.style.display = isAuthenticated ? '' : 'none';
+    }
     
     console.log('👤 Auth state updated:', { isAuthenticated, user: user?.email });
   }

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
 
     <!-- Share stays (we hide whole topbar in viewer anyway for fullscreen) -->
     <button id="shareBtn" class="iconbtn">Share</button>
+    <a id="myDesignsLink" class="iconbtn" href="my-designs.html" style="display:none">My Designs</a>
     <span id="statusText" class="pill edit-only mb-hide-when-collapsed"></span>
   </header>
 

--- a/my-designs.html
+++ b/my-designs.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>My Designs</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    body { padding-top: 60px; }
+    .design-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      padding: 16px;
+    }
+    .design-card {
+      display: block;
+      width: 200px;
+      background: #0b1630;
+      border: 1px solid #26334f;
+      border-radius: 8px;
+      text-decoration: none;
+      color: inherit;
+      overflow: hidden;
+    }
+    .design-card img {
+      width: 100%;
+      height: 120px;
+      object-fit: cover;
+      display: block;
+    }
+    .design-card h3 {
+      margin: 8px;
+      font-size: 16px;
+    }
+    .design-card .updated {
+      margin: 0 8px 8px;
+      font-size: 12px;
+      color: #94a3b8;
+    }
+  </style>
+</head>
+<body class="h-full">
+  <header class="topbar">
+    <div class="brand">My Designs</div>
+    <div class="grow"></div>
+    <a href="index.html" class="iconbtn">Back to editor</a>
+  </header>
+
+  <main>
+    <div id="designList" class="design-list"></div>
+  </main>
+
+  <script type="module" src="my-designs.js"></script>
+</body>
+</html>
+

--- a/my-designs.js
+++ b/my-designs.js
@@ -1,0 +1,48 @@
+import { apiClient } from './api-client.js';
+
+async function loadDesigns() {
+  const listEl = document.getElementById('designList');
+  if (!listEl) return;
+
+  listEl.textContent = 'Loading...';
+
+  try {
+    const designs = await apiClient.getUserDesigns();
+    listEl.textContent = '';
+
+    if (!Array.isArray(designs) || designs.length === 0) {
+      listEl.innerHTML = '<p>No designs found.</p>';
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    for (const design of designs) {
+      const id = design.id || design._id || design.projectId;
+      const thumb = design.thumbnail || design.thumbUrl || '';
+      const title = design.title || 'Untitled';
+      const updated = design.updatedAt
+        ? new Date(design.updatedAt).toLocaleString()
+        : '';
+
+      const link = document.createElement('a');
+      link.href = `index.html?project=${encodeURIComponent(id)}`;
+      link.className = 'design-card';
+      link.innerHTML = `
+        ${thumb ? `<img src="${thumb}" alt="${title}">` : ''}
+        <h3>${title}</h3>
+        <p class="updated">${updated}</p>
+      `;
+
+      fragment.appendChild(link);
+    }
+
+    listEl.appendChild(fragment);
+  } catch (err) {
+    console.error('Failed to load designs:', err);
+    listEl.innerHTML = '<p class="error">Failed to load designs.</p>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadDesigns);
+


### PR DESCRIPTION
## Summary
- Add `getUserDesigns` API call for listing current user's designs
- Introduce `my-designs.html` and `my-designs.js` to fetch and display saved designs
- Link to My Designs page from editor when authenticated

## Testing
- `node utils.test.mjs`
- `node drag-handlers.test.mjs`
- `node purchased-design-manager.test.mjs`
- `node state-manager.test.mjs` *(fails: stateManager is not defined)*
- `node ui-manager.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bb037397b0832a827984e5f9f99cfb