### PR TITLE
feat: add designs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,32 @@ await initializeApp();
 // `appInstance` is a live binding to the running application
 ```
 
+
+## Backend API
+Start the development server:
+
+```bash
+npm start
+```
+
+### GET `/api/designs`
+Returns all saved designs for the authenticated user. Authentication is
+validated via a JWT passed either as a `Bearer` token or a `session`
+cookie.
+
+**Response JSON Schema**
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "title", "thumbnailUrl", "updatedAt"],
+    "properties": {
+      "id": { "type": "string" },
+      "title": { "type": "string" },
+      "thumbnailUrl": { "type": "string", "format": "uri" },
+      "updatedAt": { "type": "string", "format": "date-time" }
+    }
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "invitation-maker",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs"
+  }
+}

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,52 @@
+// server/auth.js
+// Basic JWT validation without external dependencies.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+function parseCookies(cookieHeader = '') {
+  return Object.fromEntries(
+    cookieHeader
+      .split(';')
+      .map((c) => c.trim().split('='))
+      .filter(([k]) => k)
+  );
+}
+
+function verifyJwt(token) {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('Invalid token');
+  const [headerB64, payloadB64, sigB64] = parts;
+  const data = `${headerB64}.${payloadB64}`;
+  const expected = createHmac('sha256', SECRET).update(data).digest('base64url');
+  const sig = Buffer.from(sigB64, 'base64url');
+  const exp = Buffer.from(expected, 'base64url');
+  if (sig.length !== exp.length || !timingSafeEqual(sig, exp)) {
+    throw new Error('Invalid signature');
+  }
+  const payloadJson = Buffer.from(payloadB64, 'base64url').toString('utf8');
+  return JSON.parse(payloadJson);
+}
+
+/**
+ * Extract and validate the authenticated user from the request.
+ * Accepts either a Bearer JWT token or a `session` cookie containing a JWT.
+ * @param {import('http').IncomingMessage} req
+ * @returns {{ id: string }}
+ */
+export function authenticate(req) {
+  const auth = req.headers['authorization'];
+  let token;
+  if (auth && auth.startsWith('Bearer ')) {
+    token = auth.slice(7);
+  } else {
+    const cookies = parseCookies(req.headers['cookie']);
+    if (cookies.session) token = cookies.session;
+  }
+  if (!token) throw new Error('Missing token');
+  const payload = verifyJwt(token);
+  const userId = payload.sub || payload.userId || payload.id;
+  if (!userId) throw new Error('Invalid token payload');
+  return { id: String(userId) };
+}

--- a/server/designs-store.js
+++ b/server/designs-store.js
@@ -1,0 +1,29 @@
+// server/designs-store.js
+// Simple in-memory storage for user designs.
+// In a real application this would interface with a database.
+
+const designsByUser = {
+  demo: [
+    {
+      id: '1',
+      title: 'Sample Birthday Invite',
+      thumbnailUrl: '/images/birthday-thumb.png',
+      updatedAt: new Date('2024-01-01T12:00:00Z').toISOString()
+    },
+    {
+      id: '2',
+      title: 'Wedding Announcement',
+      thumbnailUrl: '/images/wedding-thumb.png',
+      updatedAt: new Date('2024-02-15T08:30:00Z').toISOString()
+    }
+  ]
+};
+
+/**
+ * Retrieve all designs for the provided user id.
+ * @param {string} userId
+ * @returns {Promise<Array<{id:string,title:string,thumbnailUrl:string,updatedAt:string}>>}
+ */
+export async function getDesignsByUser(userId) {
+  return designsByUser[userId] ?? [];
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,33 @@
+// server/index.js
+// Minimal HTTP server exposing GET /api/designs
+
+import http from 'node:http';
+import { authenticate } from './auth.js';
+import { getDesignsByUser } from './designs-store.js';
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === 'GET' && req.url.split('?')[0] === '/api/designs') {
+      const user = authenticate(req);
+      const designs = await getDesignsByUser(user.id);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(designs));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  } catch (err) {
+    res.writeHead(401, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unauthorized' }));
+  }
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  server.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+export default server;


### PR DESCRIPTION
## Summary
- add minimal HTTP server with `/api/designs` route
- implement HMAC-based JWT auth and in-memory designs store
- document the designs API and response schema

## Testing
- `node drag-handlers.test.mjs`
- `node purchased-design-manager.test.mjs`
- `node ui-manager.test.mjs`
- `node utils.test.mjs`
- `node state-manager.test.mjs` *(fails: ReferenceError: stateManager is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bb06d9de8c832aa2a85faf78ad9cd5