### PR TITLE
Remove status bar and helper utilities

### DIFF
--- a/auth-ui-manager.js
+++ b/auth-ui-manager.js
@@ -303,13 +303,6 @@ export class AuthUIManager {
     const isAuthenticated = apiClient.isAuthenticated();
     const user = apiClient.getUser();
     
-    // Update status text or other UI elements based on auth state
-    const statusText = document.getElementById('statusText');
-    if (statusText && isAuthenticated && user) {
-      // Could show user info in status text
-      // statusText.textContent = `Welcome, ${user.name || user.email}`;
-    }
-
     console.log('👤 Auth state updated:', { isAuthenticated, user: user?.email });
   }
 
@@ -335,39 +328,16 @@ export class AuthUIManager {
    * Show error message
    */
   showError(message) {
-    // Could implement a proper toast/notification system
-    // For now, use simple alert or status text
-    const statusText = document.getElementById('statusText');
-    if (statusText) {
-      statusText.textContent = message;
-      statusText.style.color = '#ef4444';
-      
-      // Clear after 5 seconds
-      setTimeout(() => {
-        statusText.textContent = '';
-        statusText.style.color = '';
-      }, 5000);
-    } else {
-      // Fallback to alert
-      alert(message);
-    }
+    // Basic error feedback
+    console.error(message);
+    alert(message);
   }
 
   /**
    * Show success message
    */
   showSuccess(message) {
-    const statusText = document.getElementById('statusText');
-    if (statusText) {
-      statusText.textContent = message;
-      statusText.style.color = '#10b981';
-      
-      // Clear after 3 seconds
-      setTimeout(() => {
-        statusText.textContent = '';
-        statusText.style.color = '';
-      }, 3000);
-    }
+    console.log(message);
   }
 
   /**

--- a/event-handlers.js
+++ b/event-handlers.js
@@ -382,12 +382,8 @@ export class EventHandlersManager {
       } catch (error) {
         console.error(`Error in ${elementId} ${eventType} handler:`, error);
         
-        // Show user-friendly error
-        const statusText = document.getElementById('statusText');
-        if (statusText) {
-          statusText.textContent = 'An error occurred';
-          setTimeout(() => statusText.textContent = '', 2000);
-        }
+        // User-friendly feedback
+        console.log('An error occurred');
       }
     };
 

--- a/fixed-rsvp-system.js
+++ b/fixed-rsvp-system.js
@@ -1,7 +1,6 @@
 // Fixed RSVP System - Complete RSVP functionality with guest form
 
 import { apiClient } from './api-client.js';
-import { toast } from './utils.js';
 
 // RSVP State Management
 let currentRsvpChoice = null;
@@ -238,7 +237,7 @@ async function handleRsvpSubmit(e) {
     
   } catch (error) {
     console.error('RSVP submission failed:', error);
-    toast('RSVP submission failed: ' + (error.message || 'Unknown error'));
+    console.error('RSVP submission failed: ' + (error.message || 'Unknown error'));
     
     submitBtn.textContent = originalText;
     submitBtn.disabled = false;
@@ -277,8 +276,8 @@ function showRsvpSuccess(rsvpData, isOffline = false) {
   // Auto close after 5 seconds
   setTimeout(() => successModal.remove(), 5000);
   
-  // Show toast as well
-  toast(isOffline ? 'RSVP saved locally ✓' : 'RSVP submitted successfully ✓');
+  // Show feedback as well
+  console.log(isOffline ? 'RSVP saved locally ✓' : 'RSVP submitted successfully ✓');
 }
 
 // Update RSVP button states

--- a/image-manager.js
+++ b/image-manager.js
@@ -168,11 +168,7 @@ export async function handleImageUpload(file) {
   // Validate file size first
   const maxSize = 10 * 1024 * 1024; // 10MB limit
   if (file.size > maxSize) {
-    const statusText = document.getElementById('statusText');
-    if (statusText) {
-      statusText.textContent = 'Image too large (max 10MB)';
-      setTimeout(() => statusText.textContent = '', 3000);
-    }
+    console.error('Image too large (max 10MB)');
     return;
   }
 
@@ -218,20 +214,12 @@ export async function handleImageUpload(file) {
             writeCurrentSlide();
           });
           
-          const statusText = document.getElementById('statusText');
-          if (statusText) {
-            statusText.textContent = 'Image uploaded to cloud';
-            setTimeout(() => statusText.textContent = '', 2000);
-          }
+          console.log('Image uploaded to cloud');
           
         } catch (error) {
-          console.error('Error processing uploaded image:', error);
-          imgState.has = false;
-          const statusText = document.getElementById('statusText');
-          if (statusText) {
-            statusText.textContent = 'Invalid image file';
-            setTimeout(() => statusText.textContent = '', 3000);
-          }
+        console.error('Error processing uploaded image:', error);
+        imgState.has = false;
+        console.error('Invalid image file');
         }
       };
       
@@ -244,12 +232,8 @@ export async function handleImageUpload(file) {
       return;
       
     } catch (error) {
-      console.error('Backend upload failed, using local storage:', error);
-      const statusText = document.getElementById('statusText');
-      if (statusText) {
-        statusText.textContent = 'Using local storage';
-        setTimeout(() => statusText.textContent = '', 2000);
-      }
+        console.error('Backend upload failed, using local storage:', error);
+        console.log('Using local storage');
       // Fall through to local upload
     }
   }
@@ -301,36 +285,22 @@ function fallbackToLocalUpload(file) {
         });
         
       } catch (error) {
-        console.error('Error processing local image:', error);
-        imgState.has = false;
-        const statusText = document.getElementById('statusText');
-        if (statusText) {
-          statusText.textContent = 'Invalid image file';
-          setTimeout(() => statusText.textContent = '', 3000);
-        }
+          console.error('Error processing local image:', error);
+          imgState.has = false;
+          console.error('Invalid image file');
       }
     };
     
-    userBgEl.onerror = () => {
-      console.error('Failed to load local image');
-      const statusText = document.getElementById('statusText');
-      if (statusText) {
-        statusText.textContent = 'Failed to load image';
-        setTimeout(() => statusText.textContent = '', 3000);
-      }
-    };
+      userBgEl.onerror = () => {
+        console.error('Failed to load local image');
+      };
     
     userBgEl.src = evt.target.result;
   };
   
-  reader.onerror = () => {
-    console.error('Failed to read image file');
-    const statusText = document.getElementById('statusText');
-    if (statusText) {
-      statusText.textContent = 'Failed to read file';
-      setTimeout(() => statusText.textContent = '', 3000);
-    }
-  };
+    reader.onerror = () => {
+      console.error('Failed to read image file');
+    };
   
   reader.readAsDataURL(file);
 }

--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
 
     <!-- Share stays (we hide whole topbar in viewer anyway for fullscreen) -->
     <button id="shareBtn" class="iconbtn">Share</button>
-    <span id="statusText" class="pill edit-only mb-hide-when-collapsed"></span>
   </header>
 
   <!-- Mobile topbar toggle (hidden in viewer) -->

--- a/main.js
+++ b/main.js
@@ -210,11 +210,8 @@ class InvitationMakerApp {
    * Handle initialization errors gracefully
    */
   handleInitializationError(error) {
-    const statusText = document.getElementById('statusText');
-    if (statusText) {
-      statusText.textContent = 'Failed to load editor';
-    }
-    
+    console.error('Failed to load editor', error);
+
     // Show user-friendly error
     const errorCard = document.createElement('div');
     errorCard.style.cssText = `

--- a/purchased-design-manager.js
+++ b/purchased-design-manager.js
@@ -86,27 +86,11 @@ export class PurchasedDesignManager {
     const designTitle = this.customer?.designTitle || '';
     document.title = `Customize ${designTitle} - Invitation Editor`;
     
-    // Update status text in topbar
-    this.updateStatusText();
-    
-    // Add customer info panel
-    this.addCustomerInfoPanel();
+      // Add customer info panel
+      this.addCustomerInfoPanel();
     
     // Add RSVP management panel
     this.addRSVPPanel();
-  }
-
-  /**
-   * Update status text in topbar
-   */
-  updateStatusText() {
-    const statusText = document.getElementById('statusText');
-    if (statusText && this.customer) {
-      statusText.innerHTML = `
-        <span style="color:#10b981;">${this.escapeHtml(this.customer.designTitle)}</span> • 
-        <span style="color:#6b7280;">${this.escapeHtml(String(this.customer.daysRemaining))} days left</span>
-      `;
-    }
   }
 
   /**
@@ -348,7 +332,7 @@ export class PurchasedDesignManager {
       });
 
       if (response.ok) {
-        this.showSaveSuccess();
+        console.log('Saved');
       } else {
         const error = await response.json().catch(() => ({}));
         console.error('Save failed:', error);
@@ -364,28 +348,6 @@ export class PurchasedDesignManager {
         setTimeout(() => this.saveCustomization(), 1000);
       }
     }
-  }
-
-  /**
-   * Show save success indicator
-   */
-  showSaveSuccess() {
-    const statusText = document.getElementById('statusText');
-    if (!statusText) return;
-
-    let badge = document.getElementById('savedBadge');
-    if (!badge) {
-      badge = document.createElement('span');
-      badge.id = 'savedBadge';
-      badge.style.cssText = 'margin-left:6px;color:#10b981;';
-      statusText.appendChild(badge);
-    }
-    
-    badge.textContent = '• Saved';
-    
-    // Clear the badge after 1.5 seconds
-    clearTimeout(this._savedTimer);
-    this._savedTimer = setTimeout(() => badge?.remove(), 1500);
   }
 
   /**

--- a/share-manager.js
+++ b/share-manager.js
@@ -1,6 +1,6 @@
 // share-manager.js - Fixed sharing functionality
 
-import { encodeState, decodeState, toast } from './utils.js';
+import { encodeState, decodeState } from './utils.js';
 import {
   buildProject,
   applyProject,
@@ -88,7 +88,7 @@ export async function shareCurrent() {
         const perm = await navigator.permissions?.query({ name: 'clipboard-write' });
         if (!perm || perm.state === 'granted' || perm.state === 'prompt') {
           await navigator.clipboard.writeText(url);
-          toast('Link copied ✓');
+          console.log('Link copied ✓');
         } else {
           manualCopy(url);
         }
@@ -101,7 +101,7 @@ export async function shareCurrent() {
     }
   } catch (error) {
     console.error('Share failed:', error);
-    toast('Share failed');
+    console.error('Share failed');
   }
 }
 
@@ -112,7 +112,7 @@ function manualCopy(url) {
   } catch (err) {
     console.warn('Prompt failed:', err);
   }
-  toast('Copy the link manually');
+  console.log('Copy the link manually');
 }
 
 // Apply viewer mode from URL parameters
@@ -183,7 +183,7 @@ export function applyViewerFromUrl() {
       historyState.lock = false;
     } catch (error) {
       console.warn('Failed to decode shared state:', error);
-      toast('Invalid share link');
+      console.error('Invalid share link');
     }
   }
 }

--- a/state-manager.js
+++ b/state-manager.js
@@ -1,7 +1,7 @@
 // state-manager.js - Consistent state management with clear patterns
 
 import { apiClient } from './api-client.js';
-import { debounce, toast, STORAGE_KEY, MAX_HISTORY } from './utils.js';
+import { debounce, STORAGE_KEY, MAX_HISTORY } from './utils.js';
 
 /**
  * Centralized Application State Manager
@@ -471,14 +471,14 @@ class ApplicationStateManager {
         try {
           await apiClient.getProject(this.currentProjectId);
           await apiClient.updateProject(this.currentProjectId, projectData);
-          toast('Project updated');
+          console.log('Project updated');
         } catch (error) {
           // Project not found, create new one
           if (error.message?.includes('404') || error.message?.includes('Not Found')) {
             this.currentProjectId = null;
             const response = await apiClient.saveProject(projectData);
             if (response?.projectId) this.currentProjectId = response.projectId;
-            toast('Project re-created in cloud');
+            console.log('Project re-created in cloud');
           } else {
             throw error;
           }
@@ -487,11 +487,11 @@ class ApplicationStateManager {
         // Create new project
         const response = await apiClient.saveProject(projectData);
         if (response?.projectId) this.currentProjectId = response.projectId;
-        toast('Project saved to cloud');
+        console.log('Project saved to cloud');
       }
     } catch (error) {
       console.error('Backend save failed:', error);
-      toast('Saved locally only');
+      console.log('Saved locally only');
     }
     
     // Always save locally as backup

--- a/state-manager.test.mjs
+++ b/state-manager.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import { setState, getState } from './state-manager.js';
+import stateManager, { setState, getState } from './state-manager.js';
 
 // Minimal mock HTMLElement with a circular reference to simulate DOM structure
 class MockHTMLElement {

--- a/utils.js
+++ b/utils.js
@@ -42,17 +42,6 @@ export function fmtSec(ms) {
   return (ms / 1000).toFixed(1) + 's';
 }
 
-// Toast notifications
-export function toast(msg) {
-  const statusText = document.getElementById('statusText');
-  if (!statusText) {
-    console.log(msg);
-    return;
-  }
-  statusText.textContent = msg;
-  setTimeout(() => statusText.textContent = '', 2000);
-}
-
 // URL parsing utilities
 export function getUrlParams() {
   return new URLSearchParams(location.search);
@@ -212,8 +201,7 @@ export function getElements() {
     slideLabel: document.getElementById('slideLabel'),
     
     shareBtn: document.getElementById('shareBtn'),
-    statusText: document.getElementById('statusText'),
-    
+
     slidesStrip: document.getElementById('slidesStrip'),
     addSlideBtn: document.getElementById('addSlideBtn'),
     dupSlideBtn: document.getElementById('dupSlideBtn'),


### PR DESCRIPTION
## Summary
- Remove the obsolete status bar from the top bar and strip its DOM lookups throughout the codebase.
- Replace status text helper usage with console logging and alerts; delete the `toast` helper.
- Clean up imports and references, ensuring no remaining `statusText` searches except unrelated HTTP `response.statusText`.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb953b700c832aac0092e4f3d5e307