### PR TITLE
feat: add image zoom controls

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -78,9 +78,14 @@ export function enableImageControls(on) {
   const imgFadeOutBtn = document.getElementById('imgFadeOutBtn');
   const imgFadeInRange = document.getElementById('imgFadeInRange');
   const imgFadeOutRange = document.getElementById('imgFadeOutRange');
+  const imgZoomInBtn = document.getElementById('imgZoomInBtn');
+  const imgZoomOutBtn = document.getElementById('imgZoomOutBtn');
+  const imgZoomInRange = document.getElementById('imgZoomInRange');
+  const imgZoomOutRange = document.getElementById('imgZoomOutRange');
   const presetGrid = document.querySelector('#presetGrid');
-  
-  [imgScale, imgRotate, imgFlipBtn, imgDeleteBtn, imgFadeInBtn, imgFadeOutBtn, imgFadeInRange, imgFadeOutRange].forEach(el => {
+
+  [imgScale, imgRotate, imgFlipBtn, imgDeleteBtn, imgFadeInBtn, imgFadeOutBtn, imgFadeInRange, imgFadeOutRange,
+   imgZoomInBtn, imgZoomOutBtn, imgZoomInRange, imgZoomOutRange].forEach(el => {
     if (el) el.disabled = !on;
   });
   [...presetGrid.querySelectorAll('.preset-btn')].forEach(b => b.disabled = !on);
@@ -107,6 +112,7 @@ export function syncImageControls() {
   imgRotate.value = Math.max(imgRotate.min, Math.min(imgRotate.max, deg));
   imgRotateVal.textContent = deg + '°';
   updateImageFadeUI();
+  updateImageZoomUI();
 }
 
 // Enforce image bounds within work area
@@ -323,6 +329,7 @@ export function deleteImage() {
   syncImageControls();
   highlightPreset('none');
   updateImageFadeUI();
+  updateImageZoomUI();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
   saveProjectDebounced();
 }
@@ -363,6 +370,28 @@ export function updateImageFadeUI() {
   imgFadeOutVal.textContent = fmtSec(fo);
 }
 
+export function updateImageZoomUI() {
+  const imgZoomInBtn = document.getElementById('imgZoomInBtn');
+  const imgZoomOutBtn = document.getElementById('imgZoomOutBtn');
+  const imgZoomInRange = document.getElementById('imgZoomInRange');
+  const imgZoomOutRange = document.getElementById('imgZoomOutRange');
+  const imgZoomInVal = document.getElementById('imgZoomInVal');
+  const imgZoomOutVal = document.getElementById('imgZoomOutVal');
+
+  const img = getSlideImage();
+  const on = !!(img && imgState.has);
+  [imgZoomInBtn, imgZoomOutBtn, imgZoomInRange, imgZoomOutRange].forEach(el => {
+    if (el) el.disabled = !on;
+  });
+  const zi = (img?.zoomInMs) || 0, zo = (img?.zoomOutMs) || 0;
+  imgZoomInBtn.classList.toggle('active', zi > 0);
+  imgZoomOutBtn.classList.toggle('active', zo > 0);
+  imgZoomInRange.value = zi;
+  imgZoomOutRange.value = zo;
+  imgZoomInVal.textContent = fmtSec(zi);
+  imgZoomOutVal.textContent = fmtSec(zo);
+}
+
 // Handle image fade controls
 export function handleImageFadeIn() {
   const img = getSlideImage();
@@ -398,6 +427,40 @@ export function handleImageFadeOutRange(value) {
   img.fadeOutMs = parseInt(value, 10) || 0;
   const imgFadeOutVal = document.getElementById('imgFadeOutVal');
   imgFadeOutVal.textContent = fmtSec(img.fadeOutMs);
+}
+
+export function handleImageZoomIn() {
+  const img = getSlideImage();
+  if (!img) return;
+  img.zoomInMs = (img.zoomInMs || 0) > 0 ? 0 : 800;
+  updateImageZoomUI();
+  import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
+  saveProjectDebounced();
+}
+
+export function handleImageZoomOut() {
+  const img = getSlideImage();
+  if (!img) return;
+  img.zoomOutMs = (img.zoomOutMs || 0) > 0 ? 0 : 800;
+  updateImageZoomUI();
+  import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
+  saveProjectDebounced();
+}
+
+export function handleImageZoomInRange(value) {
+  const img = getSlideImage();
+  if (!img) return;
+  img.zoomInMs = parseInt(value, 10) || 0;
+  const imgZoomInVal = document.getElementById('imgZoomInVal');
+  imgZoomInVal.textContent = fmtSec(img.zoomInMs);
+}
+
+export function handleImageZoomOutRange(value) {
+  const img = getSlideImage();
+  if (!img) return;
+  img.zoomOutMs = parseInt(value, 10) || 0;
+  const imgZoomOutVal = document.getElementById('imgZoomOutVal');
+  imgZoomOutVal.textContent = fmtSec(img.zoomOutMs);
 }
 
 // Image scaling and rotation handlers

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -319,6 +319,8 @@ export function writeCurrentSlide() {
         flip: !!imgState.flip,
         fadeInMs: slides[activeIndex]?.image?.fadeInMs || 0,
         fadeOutMs: slides[activeIndex]?.image?.fadeOutMs || 0,
+        zoomInMs: slides[activeIndex]?.image?.zoomInMs || 0,
+        zoomOutMs: slides[activeIndex]?.image?.zoomOutMs || 0,
       };
     }
 

--- a/utils.js
+++ b/utils.js
@@ -142,7 +142,9 @@ function compressProjectData(project) {
         angle: Math.round(slide.image.angle * 100) / 100,
         flip: slide.image.flip,
         fadeInMs: slide.image.fadeInMs,
-        fadeOutMs: slide.image.fadeOutMs
+        fadeOutMs: slide.image.fadeOutMs,
+        zoomInMs: slide.image.zoomInMs,
+        zoomOutMs: slide.image.zoomOutMs
       } : null,
       layers: slide.layers?.map(layer => ({
         text: layer.text,


### PR DESCRIPTION
## Summary
- support zoom-in/zoom-out durations for slide images
- add UI handlers to toggle and adjust zoom effects
- persist zoom transition data with slides

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb978922a0832aa719ece1c7985d1b