### PR TITLE
Add generateId utility and tests

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,11 @@
 // Math and validation utilities
 export const clamp = (v, min, max) => Math.min(max, Math.max(min, v));
 
+// Unique ID generation
+export function generateId(prefix = 'id') {
+  return `${prefix}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
 // Debounce utility for performance
 export function debounce(fn, delay = 300) {
   let t;

--- a/utils.test.mjs
+++ b/utils.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { encodeState, decodeState, workSize } from './utils.js';
+import { encodeState, decodeState, workSize, generateId } from './utils.js';
 
 // A minimal project state containing non-ASCII characters to verify
 // Unicode-safe base64 round-tripping.
@@ -82,3 +82,11 @@ console.log('decodeState rejects malformed input');
 global.document = { querySelector: () => null };
 assert.deepStrictEqual(workSize(), { w: 0, h: 0 });
 console.log('workSize returns fallback when #work is absent');
+
+// generateId should produce unique, prefixed IDs
+const gid1 = generateId('test');
+const gid2 = generateId('test');
+assert.ok(gid1.startsWith('test-'));
+assert.ok(gid2.startsWith('test-'));
+assert.notStrictEqual(gid1, gid2);
+console.log('generateId creates unique prefixed IDs');


### PR DESCRIPTION
## Summary
- add generateId utility for prefix-based unique IDs
- test generateId for proper prefixing and uniqueness

## Testing
- `npm test` *(fails: document.body.classList.remove is not a function)*
- `node utils.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bc5c1e8370832a9a32af73d00de7e2