### PR TITLE
Use playSlides for play button handler

### DIFF
--- a/event-handlers.js
+++ b/event-handlers.js
@@ -75,8 +75,8 @@ export class EventHandlersManager {
     });
 
     this.registerClickHandler('playSlidesBtn', async () => {
-      const { togglePlay } = await import('./slide-manager.js');
-      togglePlay();
+      const { playSlides } = await import('./slide-manager.js');
+      playSlides();
     });
   }
 


### PR DESCRIPTION
## Summary
- Replace togglePlay with playSlides in slide navigation handler to trigger slide playback

## Testing
- `npm test` *(fails: document.body.classList.remove is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bc61286ee0832aaf9ab8b2e98729f1