### PR TITLE
Scale uploaded images to fit canvas

### DIFF
--- a/drag-handlers.js
+++ b/drag-handlers.js
@@ -605,16 +605,16 @@ export class DragHandlersManager {
    */
   forceEndDrag() {
     try {
-      document.body.classList.remove('dragging');
-      
-      if (this.dragState?.element) {
+      document.body?.classList?.remove?.('dragging');
+
+      if (this.dragState?.element?.classList) {
         this.dragState.element.classList.remove('dragging');
       }
-      
+
       if (this.ctx.hideGuides) {
         this.ctx.hideGuides();
       }
-      
+
       if (this.ctx.endDragText) {
         this.ctx.endDragText();
       }

--- a/image-manager.js
+++ b/image-manager.js
@@ -226,7 +226,7 @@ export function setTransforms() {
   syncImageControls();
 }
 
-// FIXED: Handle image upload with 100% default scaling
+// Handle image upload defaulting to fit within work area
 export async function handleImageUpload(file) {
   // Validate file size first
   const maxSize = 10 * 1024 * 1024; // 10MB limit
@@ -253,12 +253,12 @@ export async function handleImageUpload(file) {
           
           const r = work.getBoundingClientRect();
           
-          // FIXED: Set default scale to 100% coverage instead of 95%
+          // Set default scale so image fits entirely within work area
           const scaleToFitWidth = r.width / imgState.natW;
           const scaleToFitHeight = r.height / imgState.natH;
-          
-          // Use the larger scale to ensure full coverage (100%)
-          imgState.scale = Math.max(scaleToFitWidth, scaleToFitHeight);
+
+          // Use the smaller scale and avoid upscaling beyond 100%
+          imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
           
           imgState.angle = 0;
           imgState.signX = 1;
@@ -285,7 +285,7 @@ export async function handleImageUpload(file) {
             writeCurrentSlide();
           });
           
-          console.log('✅ Image uploaded to cloud at 100% scale');
+          console.log('✅ Image uploaded to cloud with fit-to-canvas scale');
           
         } catch (error) {
           console.error('Error processing uploaded image:', error);
@@ -310,7 +310,7 @@ export async function handleImageUpload(file) {
   fallbackToLocalUpload(file);
 }
 
-// FIXED: Local upload fallback with 100% scaling
+// Local upload fallback with fit-to-canvas scaling
 function fallbackToLocalUpload(file) {
   const userBgEl = document.querySelector('#userBg');
   const work = document.querySelector('#work');
@@ -326,12 +326,12 @@ function fallbackToLocalUpload(file) {
       
       const r = work.getBoundingClientRect();
       
-      // FIXED: Set default scale to 100% coverage
+      // Set default scale so image fits within work area
       const scaleToFitWidth = r.width / imgState.natW;
       const scaleToFitHeight = r.height / imgState.natH;
-      
-      // Use the larger scale for full coverage
-      imgState.scale = Math.max(scaleToFitWidth, scaleToFitHeight);
+
+      // Use the smaller scale and avoid upscaling beyond 100%
+      imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
       
       imgState.angle = 0;
       imgState.signX = 1;
@@ -358,7 +358,7 @@ function fallbackToLocalUpload(file) {
         writeCurrentSlide();
       });
       
-      console.log('✅ Local image loaded at 100% scale');
+        console.log('✅ Local image loaded with fit-to-canvas scale');
       
     } catch (error) {
       console.error('Error processing local image:', error);

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -126,7 +126,7 @@ class ImageLoader {
   }
 
   /**
-   * FIXED: Load slide image with 100% default scaling
+   * Load slide image defaulting to fit within the work area
    */
   async loadSlideImage(slide) {
     // Cancel any previous load
@@ -167,7 +167,7 @@ class ImageLoader {
           const centerX = workRect.width / 2;
           const centerY = workRect.height / 2;
           
-          // Use saved values or calculate 100% defaults
+          // Use saved values or calculate fit-to-canvas defaults
           if (slide.image && typeof slide.image.scale === 'number') {
             imgState.scale = slide.image.scale;
             imgState.angle = slide.image.angle || 0;
@@ -177,12 +177,12 @@ class ImageLoader {
             imgState.cx = slide.image.cx || centerX;
             imgState.cy = slide.image.cy || centerY;
           } else {
-            // FIXED: Default to 100% scale (full coverage) instead of 95%
+            // Default to scale that keeps entire image visible
             const scaleToFitWidth = workRect.width / imgState.natW;
             const scaleToFitHeight = workRect.height / imgState.natH;
-            
-            // Use the larger scale for 100% coverage
-            imgState.scale = Math.max(scaleToFitWidth, scaleToFitHeight);
+
+            // Use the smaller scale and avoid upscaling beyond 100%
+            imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
             
             imgState.angle = 0;
             imgState.signX = 1;
@@ -193,7 +193,7 @@ class ImageLoader {
           }
           
           setTransforms();
-          console.log('✅ Slide image loaded with 100% scale:', imgState.scale);
+          console.log('✅ Slide image loaded with fit-to-canvas scale:', imgState.scale);
           
         } catch (error) {
           console.warn('Image processing error:', error);


### PR DESCRIPTION
## Summary
- Scale uploaded images to fit entirely within the work area instead of covering it
- Load slide images using the same fit-to-canvas behavior
- Harden drag cleanup by guarding classList operations

## Testing
- `npm test` *(fails: AssertionError 1 !== 0 in drag-handlers.test.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68bc693c54d0832a90b638144d2eddf6