### PR TITLE
Add image shearing state and persistence

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -14,6 +14,8 @@ export const imgState = {
   cy: 0,
   scale: 1,
   angle: 0,
+  shearX: 0,
+  shearY: 0,
   signX: 1,
   signY: 1,
   flip: false,
@@ -199,7 +201,7 @@ export function setTransforms() {
   const h = imgState.natH * imgState.scale;
   const sx = (imgState.flip ? -1 : 1) * (imgState.signX ?? 1);
   const sy = imgState.signY ?? 1;
-  const base = `translate(-50%,-50%) rotate(${imgState.angle}rad) scale(${imgState.scale * sx}, ${imgState.scale * sy})`;
+  const base = `translate(-50%,-50%) rotate(${imgState.angle}rad) skew(${imgState.shearX}rad, ${imgState.shearY}rad) scale(${imgState.scale * sx}, ${imgState.scale * sy})`;
 
   if (userBgWrap) {
     userBgWrap.style.width = w + 'px';
@@ -259,8 +261,10 @@ export async function handleImageUpload(file) {
 
           // Use the smaller scale and avoid upscaling beyond 100%
           imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
-          
+
           imgState.angle = 0;
+          imgState.shearX = 0;
+          imgState.shearY = 0;
           imgState.signX = 1;
           imgState.signY = 1;
           imgState.flip = false;
@@ -332,8 +336,10 @@ function fallbackToLocalUpload(file) {
 
       // Use the smaller scale and avoid upscaling beyond 100%
       imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
-      
+
       imgState.angle = 0;
+      imgState.shearX = 0;
+      imgState.shearY = 0;
       imgState.signX = 1;
       imgState.signY = 1;
       imgState.flip = false;
@@ -566,6 +572,8 @@ export function handleImageDelete() {
   imgState.cy = 0;
   imgState.scale = 1;
   imgState.angle = 0;
+  imgState.shearX = 0;
+  imgState.shearY = 0;
   imgState.signX = 1;
   imgState.signY = 1;
   imgState.flip = false;

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -137,6 +137,8 @@ class ImageLoader {
     
     if (!chosenSrc) {
       imgState.has = false;
+      imgState.shearX = 0;
+      imgState.shearY = 0;
       if (userBg) userBg.src = '';
       setTransforms();
       return;
@@ -171,6 +173,8 @@ class ImageLoader {
           if (slide.image && typeof slide.image.scale === 'number') {
             imgState.scale = slide.image.scale;
             imgState.angle = slide.image.angle || 0;
+            imgState.shearX = slide.image.shearX || 0;
+            imgState.shearY = slide.image.shearY || 0;
             imgState.signX = slide.image.signX ?? 1;
             imgState.signY = slide.image.signY ?? 1;
             imgState.flip = !!slide.image.flip;
@@ -183,8 +187,10 @@ class ImageLoader {
 
             // Use the smaller scale and avoid upscaling beyond 100%
             imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
-            
+
             imgState.angle = 0;
+            imgState.shearX = 0;
+            imgState.shearY = 0;
             imgState.signX = 1;
             imgState.signY = 1;
             imgState.flip = false;
@@ -198,6 +204,8 @@ class ImageLoader {
         } catch (error) {
           console.warn('Image processing error:', error);
           imgState.has = false;
+          imgState.shearX = 0;
+          imgState.shearY = 0;
           setTransforms();
         }
         
@@ -207,6 +215,8 @@ class ImageLoader {
       const onError = () => {
         if (!loadOperation.cancelled) {
           imgState.has = false;
+          imgState.shearX = 0;
+          imgState.shearY = 0;
           setTransforms();
         }
         resolve();
@@ -258,6 +268,8 @@ export async function loadSlideIntoDOM(slide) {
     
     // Reset image state
     imgState.has = false;
+    imgState.shearX = 0;
+    imgState.shearY = 0;
 
     // Ensure zoom timing defaults exist
     if (slide?.image) {
@@ -416,6 +428,8 @@ export function writeCurrentSlide() {
         src: document.querySelector('#userBg')?.src || '',
         scale: imgState.scale,
         angle: imgState.angle,
+        shearX: imgState.shearX,
+        shearY: imgState.shearY,
         signX: imgState.signX,
         signY: imgState.signY,
         flip: imgState.flip,


### PR DESCRIPTION
## Summary
- Track horizontal and vertical shear for images and apply via CSS skew
- Reset shear on uploads, deletes, and slide loads
- Persist shear values when saving and loading slides

## Testing
- `npm test` *(fails: drag-handlers.test.mjs assertion)*
- `node purchased-design-manager.test.mjs`
- `node ui-manager.test.mjs` *(fails: ui-manager.test.mjs assertion)*
- `node utils.test.mjs`
- `node state-manager.test.mjs` *(fails: state-manager.test.mjs assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d16b3f0832ab6fc8f8667848097