### PR TITLE
feat: persist image shearing

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -14,6 +14,8 @@ export const imgState = {
   cy: 0,
   scale: 1,
   angle: 0,
+  shearX: 0,
+  shearY: 0,
   signX: 1,
   signY: 1,
   flip: false,
@@ -261,6 +263,8 @@ export async function handleImageUpload(file) {
           imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
           
           imgState.angle = 0;
+          imgState.shearX = 0;
+          imgState.shearY = 0;
           imgState.signX = 1;
           imgState.signY = 1;
           imgState.flip = false;
@@ -334,6 +338,8 @@ function fallbackToLocalUpload(file) {
       imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
       
       imgState.angle = 0;
+      imgState.shearX = 0;
+      imgState.shearY = 0;
       imgState.signX = 1;
       imgState.signY = 1;
       imgState.flip = false;
@@ -566,6 +572,8 @@ export function handleImageDelete() {
   imgState.cy = 0;
   imgState.scale = 1;
   imgState.angle = 0;
+  imgState.shearX = 0;
+  imgState.shearY = 0;
   imgState.signX = 1;
   imgState.signY = 1;
   imgState.flip = false;

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -171,6 +171,8 @@ class ImageLoader {
           if (slide.image && typeof slide.image.scale === 'number') {
             imgState.scale = slide.image.scale;
             imgState.angle = slide.image.angle || 0;
+            imgState.shearX = slide.image.shearX ?? 0;
+            imgState.shearY = slide.image.shearY ?? 0;
             imgState.signX = slide.image.signX ?? 1;
             imgState.signY = slide.image.signY ?? 1;
             imgState.flip = !!slide.image.flip;
@@ -183,8 +185,10 @@ class ImageLoader {
 
             // Use the smaller scale and avoid upscaling beyond 100%
             imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
-            
+
             imgState.angle = 0;
+            imgState.shearX = 0;
+            imgState.shearY = 0;
             imgState.signX = 1;
             imgState.signY = 1;
             imgState.flip = false;
@@ -416,6 +420,8 @@ export function writeCurrentSlide() {
         src: document.querySelector('#userBg')?.src || '',
         scale: imgState.scale,
         angle: imgState.angle,
+        shearX: imgState.shearX,
+        shearY: imgState.shearY,
         signX: imgState.signX,
         signY: imgState.signY,
         flip: imgState.flip,


### PR DESCRIPTION
## Summary
- store `shearX`/`shearY` when saving slide image state
- load `shearX`/`shearY` into imgState with 0 defaults
- extend imgState to track shearing and reset on new image/delete

## Testing
- `npm test` *(fails: drag-handlers.test.mjs:63 1 !== 0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d73df58832ab3326e5797c2a149