### PR TITLE
Add startPlay function to handle slide autoplay

### DIFF
--- a/slide-manager.js
+++ b/slide-manager.js
@@ -596,6 +596,12 @@ let slidePlayback = {
   startTime: 0
 };
 
+export function startPlay() {
+  if (!slidePlayback.isPlaying) {
+    playSlides();
+  }
+}
+
 export function playSlides() {
   if (slidePlayback.isPlaying) {
     stopSlides();


### PR DESCRIPTION
## Summary
- Add `startPlay` utility in `slide-manager` to safely start slideshow playback
- Ensure viewer mode uses `startPlay` via existing import in `share-manager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd9a9e2154832ab64f2a7d6c2c16b6