### PR TITLE
Preserve shearing and scale sign in shared project data

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -146,6 +146,10 @@ function compressProjectData(project) {
         cy: Math.round((slide.image.cy || 0) * 100) / 100,
         scale: Math.round((slide.image.scale || 1) * 1000) / 1000, // Round to 3 decimal places
         angle: Math.round((slide.image.angle || 0) * 100) / 100,
+        shearX: Math.round((slide.image.shearX || 0) * 1000) / 1000,
+        shearY: Math.round((slide.image.shearY || 0) * 1000) / 1000,
+        signX: slide.image.signX === -1 ? -1 : undefined,
+        signY: slide.image.signY === -1 ? -1 : undefined,
         flip: slide.image.flip || false,
         fadeInMs: slide.image.fadeInMs,
         fadeOutMs: slide.image.fadeOutMs,

--- a/utils.test.mjs
+++ b/utils.test.mjs
@@ -74,6 +74,41 @@ assert.strictEqual(decodedZoom.slides[0].image.zoomInMs, 300);
 assert.strictEqual(decodedZoom.slides[0].layers[0].zoomOutMs, 40);
 console.log('zoom timing fields persist through encode/decode');
 
+// Shear and sign values should survive round-trip
+const projectShear = {
+  v: 1,
+  slides: [
+    {
+      image: {
+        src: 'http://example.com/a.jpg',
+        thumb: null,
+        cx: 0,
+        cy: 0,
+        scale: 1,
+        angle: 0,
+        flip: false,
+        shearX: 0.123,
+        shearY: -0.456,
+        signX: -1,
+        signY: -1
+      },
+      layers: [],
+      workSize: { w: 100, h: 100 },
+      durationMs: 1000
+    }
+  ],
+  activeIndex: 0,
+  defaults: {},
+};
+
+const encodedShear = encodeState(projectShear);
+const decodedShear = decodeState(encodedShear);
+assert.strictEqual(decodedShear.slides[0].image.shearX, 0.123);
+assert.strictEqual(decodedShear.slides[0].image.shearY, -0.456);
+assert.strictEqual(decodedShear.slides[0].image.signX, -1);
+assert.strictEqual(decodedShear.slides[0].image.signY, -1);
+console.log('shear and sign values persist through encode/decode');
+
 // Invalid data should throw a clear error
 assert.throws(() => decodeState('not_base64!'), /Invalid or corrupted/);
 console.log('decodeState rejects malformed input');


### PR DESCRIPTION
## Summary
- Keep image shearX/shearY and negative scale sign when compressing project data
- Test encodeState/decodeState round trip for shear and sign values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9c7fefc4832a8abc86c0b495f017