### PR TITLE
Preserve image shear in shared project data

### DIFF
--- a/share-manager.js
+++ b/share-manager.js
@@ -25,22 +25,48 @@ function getViewerOrigin() {
 }
 
 // Prepare project data for sharing (trim huge inline images, keep remote URLs)
-export function safeProjectForShare() {
-  const p = buildProject();
+// Optionally accepts a project object to operate on for easier testing
+export function safeProjectForShare(project) {
+  const p = project ? JSON.parse(JSON.stringify(project)) : buildProject();
   p.slides = (p.slides || []).map((s) => {
-    const img = s.image ? { ...s.image } : null;
-    if (img) {
-      const src = img.src || '';
-      const isRemote = /^https?:\/\//i.test(src);
-      const isDataUrl = /^data:/i.test(src);
+    let img = null;
+    if (s.image) {
+      const {
+        src,
+        thumb,
+        cx,
+        cy,
+        scale,
+        angle,
+        shearX,
+        shearY,
+        signX,
+        signY,
+        flip,
+        fadeInMs,
+        fadeOutMs,
+        zoomInMs,
+        zoomOutMs
+      } = s.image;
 
-      // Keep remote URLs always (R2, CDN, etc.). Strip only data URLs to avoid giant hashes.
-      if (isDataUrl) {
-        img.src = null;
-      }
-
-      // Don't touch thumb/transformations — viewer needs these.
-      // If both src and thumb end up null, the viewer will just show no image for that slide.
+      const isDataUrl = /^data:/i.test(src || '');
+      img = {
+        src: isDataUrl ? null : (src || null),
+        thumb: thumb ?? null,
+        cx: cx ?? 0,
+        cy: cy ?? 0,
+        scale: scale ?? 1,
+        angle: angle ?? 0,
+        shearX: shearX ?? 0,
+        shearY: shearY ?? 0,
+        signX: signX ?? 1,
+        signY: signY ?? 1,
+        flip: !!flip,
+        fadeInMs,
+        fadeOutMs,
+        zoomInMs,
+        zoomOutMs
+      };
     }
     return { ...s, image: img };
   });

--- a/utils.test.mjs
+++ b/utils.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { encodeState, decodeState, workSize, generateId } from './utils.js';
+import { safeProjectForShare } from './share-manager.js';
 
 // A minimal project state containing non-ASCII characters to verify
 // Unicode-safe base64 round-tripping.
@@ -108,6 +109,14 @@ assert.strictEqual(decodedShear.slides[0].image.shearY, -0.456);
 assert.strictEqual(decodedShear.slides[0].image.signX, -1);
 assert.strictEqual(decodedShear.slides[0].image.signY, -1);
 console.log('shear and sign values persist through encode/decode');
+
+// safeProjectForShare should retain shear values before encoding
+const safeShear = safeProjectForShare(projectShear);
+const encodedSafeShear = encodeState(safeShear);
+const decodedSafeShear = decodeState(encodedSafeShear);
+assert.strictEqual(decodedSafeShear.slides[0].image.shearX, 0.123);
+assert.strictEqual(decodedSafeShear.slides[0].image.shearY, -0.456);
+console.log('safeProjectForShare preserves shear values');
 
 // Invalid data should throw a clear error
 assert.throws(() => decodeState('not_base64!'), /Invalid or corrupted/);


### PR DESCRIPTION
## Summary
- ensure `safeProjectForShare` keeps `shearX`/`shearY` and copies only needed image fields
- add regression test verifying shear survives sharing and round-trip encoding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda295c2dc832a85e52bb4b8885af7