### PR TITLE
Preserve shear values during image upload

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -259,22 +259,26 @@ export async function handleImageUpload(file) {
           }
           
           const r = work.getBoundingClientRect();
-          
+
           // Set default scale so image fits entirely within work area
           const scaleToFitWidth = r.width / imgState.natW;
           const scaleToFitHeight = r.height / imgState.natH;
 
+          const { shearX, shearY } = imgState;
+
           // Use the smaller scale and avoid upscaling beyond 100%
           imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
           imgState.angle = 0;
-          imgState.shearX = 0;
-          imgState.shearY = 0;
+          // imgState.shearX = 0;
+          // imgState.shearY = 0;
           imgState.signX = 1;
           imgState.signY = 1;
           imgState.flip = false;
           imgState.cx = r.width / 2;
           imgState.cy = r.height / 2;
           imgState.has = true;
+          imgState.shearX = shearX;
+          imgState.shearY = shearY;
           
           // Reset filters
           Object.assign(imgFilters, PRESETS.none);


### PR DESCRIPTION
## Summary
- Preserve existing shear transforms when a new image is loaded by capturing and reapplying shear values instead of resetting them.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdad89ac78832a8f47cdb2ec17ea38