### PR TITLE
Initialize local image transform and preserve orientation

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -341,7 +341,19 @@ function fallbackToLocalUpload(file) {
       // Set default scale so image fits within work area
       const scaleToFitWidth = r.width / imgState.natW;
       const scaleToFitHeight = r.height / imgState.natH;
-      
+
+      const { shearX, shearY, signX, signY, flip } = imgState;
+      imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
+      imgState.angle ??= 0;
+      imgState.cx = r.width / 2;
+      imgState.cy = r.height / 2;
+      imgState.has = true;
+      imgState.shearX = shearX;
+      imgState.shearY = shearY;
+      imgState.signX = signX;
+      imgState.signY = signY;
+      imgState.flip = flip;
+
       // Reset filters
       Object.assign(imgFilters, PRESETS.none);
       highlightPreset('none');


### PR DESCRIPTION
## Summary
- Set initial transform state for local image uploads, fitting images to canvas
- Preserve shear, sign, and flip values when loading local images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdaf92d10c832ab9dc5d3fe777a808