### PR TITLE
refactor: rename image delete handler

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -569,7 +569,7 @@ export function handleImageFlip() {
 }
 
 // Delete image handler
-export function handleImageDelete() {
+export function deleteImage() {
   if (!imgState.has) return;
   
   imgState.has = false;


### PR DESCRIPTION
## Summary
- rename `handleImageDelete` to `deleteImage`
- verify `event-handlers.js` imports `deleteImage` correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc4bd3f7c832a96a9e78f8ccea3d8