### PR TITLE
Start slide playback from active slide

### DIFF
--- a/slide-manager.js
+++ b/slide-manager.js
@@ -612,7 +612,7 @@ export function playSlides() {
   if (slides.length === 0) return;
   
   slidePlayback.isPlaying = true;
-  slidePlayback.currentSlideIndex = 0;
+  slidePlayback.currentSlideIndex = getActiveIndex();
   slidePlayback.startTime = Date.now();
   
   // Update play button


### PR DESCRIPTION
## Summary
- Begin slide playback from the currently active slide instead of always starting at the first slide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc72d621c832a9e161335a012155f