### PR TITLE
Remove existing scale before applying zoom in Slide Manager

### DIFF
--- a/slide-manager.js
+++ b/slide-manager.js
@@ -216,15 +216,16 @@ function stepFrame(timestamp) {
       imageData.zoomOutMs || 0
     );
     
-    // Get current transform from setTransforms and apply zoom
+    // Get current transform from setTransforms, remove any existing scale
     const currentTransform = userBg.style.transform || '';
-    
+    const base = currentTransform.replace(/scale\([^)]*\)/g, '').trim();
+
     if (zoomScale !== 1) {
       // Apply zoom on top of existing transform
-      userBg.style.transform = `${currentTransform} scale(${zoomScale})`.trim();
+      userBg.style.transform = `${base} scale(${zoomScale})`.trim();
     } else {
       // Reset to just the original transform
-      userBg.style.transform = currentTransform.replace(/scale\([^)]*\)/g, '').trim();
+      userBg.style.transform = base;
     }
   }
   


### PR DESCRIPTION
## Summary
- Strip any previous `scale()` transform before applying new zoom scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdda3e6ab8832a9b0ac04e2833d206