### PR TITLE
Ensure preview button aria-pressed reflects mode

### DIFF
--- a/ui-manager.js
+++ b/ui-manager.js
@@ -84,14 +84,18 @@ export function togglePreview() {
 
 export function enterPreview() {
   document.body.classList.add('preview');
+  const previewBtn = document.getElementById('previewBtn');
+  previewBtn?.setAttribute('aria-pressed', 'true');
   previewMode = true;
-  
+
   // Ensure RSVP bar is visible in preview mode
   ensureRsvpVisibility();
 }
 
 export function exitPreview() {
   document.body.classList.remove('preview');
+  const previewBtn = document.getElementById('previewBtn');
+  previewBtn?.setAttribute('aria-pressed', 'false');
   previewMode = false;
 }
 

--- a/ui-manager.test.mjs
+++ b/ui-manager.test.mjs
@@ -61,7 +61,7 @@ global.window = {
 };
 
 const ui = await import('./ui-manager.js');
-const { setMobileTopbarCollapsed, togglePanel } = ui;
+const { setMobileTopbarCollapsed, togglePanel, enterPreview, exitPreview } = ui;
 
 const body = document.body;
 const topbarToggle = document.getElementById('topbarToggle');
@@ -90,3 +90,13 @@ togglePanel(); // closes panel
 assert.ok(!body.classList.contains('panel-open'));
 assert.strictEqual(togglePanelBtn.getAttribute('aria-expanded'), 'false');
 console.log('togglePanel opens and closes the editor panel');
+
+// --- enterPreview / exitPreview ---
+enterPreview();
+assert.ok(body.classList.contains('preview'));
+assert.strictEqual(previewBtn.getAttribute('aria-pressed'), 'true');
+
+exitPreview();
+assert.ok(!body.classList.contains('preview'));
+assert.strictEqual(previewBtn.getAttribute('aria-pressed'), 'false');
+console.log('enterPreview and exitPreview toggle preview mode and aria-pressed');


### PR DESCRIPTION
## Summary
- Set `aria-pressed` on preview button when entering and exiting preview mode
- Test preview mode toggling updates `aria-pressed` state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdddc5f4b8832a8ea6ac4f6dc42055