### PR TITLE
Add active state styling for panel toggle button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -267,6 +267,13 @@ body {
   cursor: not-allowed;
 }
 
+.iconbtn.active,
+.iconbtn[aria-expanded="true"] {
+  border-color: var(--accent);
+  background: rgba(37, 99, 235, 0.1);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
 .pill {
   font-variant-numeric: tabular-nums;
   font-size: 11px;

--- a/ui-manager.js
+++ b/ui-manager.js
@@ -61,6 +61,7 @@ export function openPanel() {
   const togglePanelBtn = document.getElementById('togglePanelBtn');
   const previewBtn = document.getElementById('previewBtn');
   togglePanelBtn?.setAttribute('aria-expanded', 'true');
+  togglePanelBtn?.classList.add('active');
   previewBtn?.setAttribute('aria-pressed', 'false');
   sidebarOpen = true;
   syncTopbarHeight();
@@ -70,6 +71,7 @@ export function closePanel() {
   document.body.classList.remove('panel-open');
   const togglePanelBtn = document.getElementById('togglePanelBtn');
   togglePanelBtn?.setAttribute('aria-expanded', 'false');
+  togglePanelBtn?.classList.remove('active');
   sidebarOpen = false;
   syncTopbarHeight();
 }

--- a/ui-manager.test.mjs
+++ b/ui-manager.test.mjs
@@ -85,10 +85,12 @@ togglePanel(); // opens panel
 assert.ok(body.classList.contains('panel-open'));
 assert.strictEqual(togglePanelBtn.getAttribute('aria-expanded'), 'true');
 assert.strictEqual(previewBtn.getAttribute('aria-pressed'), 'false');
+assert.ok(togglePanelBtn.classList.contains('active'));
 
 togglePanel(); // closes panel
 assert.ok(!body.classList.contains('panel-open'));
 assert.strictEqual(togglePanelBtn.getAttribute('aria-expanded'), 'false');
+assert.ok(!togglePanelBtn.classList.contains('active'));
 console.log('togglePanel opens and closes the editor panel');
 
 // --- enterPreview / exitPreview ---


### PR DESCRIPTION
## Summary
- Highlight panel toggle button with `.active` class and aria state
- Add CSS rules for active icon buttons
- Test panel toggle button active state

## Testing
- `npm test` (fails: DOMException InvalidCharacterError, ReferenceError: document is not defined)
- `node ui-manager.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bddf70a4e4832aace1cf733bf6b892