### PR TITLE
Highlight active state for preview button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -268,7 +268,8 @@ body {
 }
 
 .iconbtn.active,
-.iconbtn[aria-expanded="true"] {
+.iconbtn[aria-expanded="true"],
+.iconbtn[aria-pressed="true"] {
   border-color: var(--accent);
   background: rgba(37, 99, 235, 0.1);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);

--- a/ui-manager.js
+++ b/ui-manager.js
@@ -88,6 +88,7 @@ export function enterPreview() {
   document.body.classList.add('preview');
   const previewBtn = document.getElementById('previewBtn');
   previewBtn?.setAttribute('aria-pressed', 'true');
+  previewBtn?.classList.add('active');
   previewMode = true;
 
   // Ensure RSVP bar is visible in preview mode
@@ -98,6 +99,7 @@ export function exitPreview() {
   document.body.classList.remove('preview');
   const previewBtn = document.getElementById('previewBtn');
   previewBtn?.setAttribute('aria-pressed', 'false');
+  previewBtn?.classList.remove('active');
   previewMode = false;
 }
 

--- a/ui-manager.test.mjs
+++ b/ui-manager.test.mjs
@@ -97,8 +97,10 @@ console.log('togglePanel opens and closes the editor panel');
 enterPreview();
 assert.ok(body.classList.contains('preview'));
 assert.strictEqual(previewBtn.getAttribute('aria-pressed'), 'true');
+assert.ok(previewBtn.classList.contains('active'));
 
 exitPreview();
 assert.ok(!body.classList.contains('preview'));
 assert.strictEqual(previewBtn.getAttribute('aria-pressed'), 'false');
+assert.ok(!previewBtn.classList.contains('active'));
 console.log('enterPreview and exitPreview toggle preview mode and aria-pressed');


### PR DESCRIPTION
## Summary
- Mark Preview button active when entering preview mode and remove when exiting
- Highlight buttons using `aria-pressed="true"`
- Test preview button active state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde0f7c970832a8677985e2e79d89c