### PR TITLE
Ensure history updates after user changes

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -2,8 +2,7 @@
 
 import { apiClient } from './api-client.js';
 import { clamp } from './utils.js';
-import { getSlides, getActiveIndex } from './state-manager.js';
-import { saveProjectDebounced } from './state-manager.js';
+import { getSlides, getActiveIndex, saveProjectDebounced, recordHistory } from './state-manager.js';
 
 // Image state management
 export const imgState = {
@@ -46,6 +45,11 @@ export const PRESETS = {
   cool: { blur: 0, brightness: 100, contrast: 105, grayscale: 0, hueRotate: 200, invert: 0, saturate: 110, sepia: 0, opacity: 100 },
   dramatic: { blur: 0, brightness: 95, contrast: 140, grayscale: 0, hueRotate: 0, invert: 0, saturate: 130, sepia: 0, opacity: 100 }
 };
+
+function saveAndRecord() {
+  saveProjectDebounced();
+  recordHistory();
+}
 
 // FIXED: Get slide image helper function (no import needed)
 function getSlideImage() {
@@ -439,7 +443,7 @@ export function applyPreset(name) {
   Object.assign(imgFilters, PRESETS[name] || PRESETS.none);
   highlightPreset(name);
   setTransforms();
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 // Image controls management
@@ -475,7 +479,7 @@ export function handleImageFadeIn() {
   img.fadeInMs = (img.fadeInMs || 0) > 0 ? 0 : 800;
   updateImageFadeUI();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 export function handleImageFadeOut() {
@@ -484,7 +488,7 @@ export function handleImageFadeOut() {
   img.fadeOutMs = (img.fadeOutMs || 0) > 0 ? 0 : 800;
   updateImageFadeUI();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 export function handleImageFadeInRange(value) {
@@ -510,7 +514,7 @@ export function handleImageZoomIn() {
   img.zoomInMs = (img.zoomInMs || 0) > 0 ? 0 : 800;
   updateImageZoomUI();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 export function handleImageZoomOut() {
@@ -519,7 +523,7 @@ export function handleImageZoomOut() {
   img.zoomOutMs = (img.zoomOutMs || 0) > 0 ? 0 : 800;
   updateImageZoomUI();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 export function handleImageZoomInRange(value) {
@@ -545,7 +549,7 @@ export function handleImageScale(value) {
   enforceImageBounds();
   setTransforms();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 // Image rotate handler (UI slider gives degrees; we store radians)
@@ -556,7 +560,7 @@ export function handleImageRotate(value) {
   enforceImageBounds();
   setTransforms();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 // Image flip handler
@@ -565,7 +569,7 @@ export function handleImageFlip() {
   imgState.flip = !imgState.flip;
   setTransforms();
   import('./slide-manager.js').then(({ writeCurrentSlide }) => writeCurrentSlide());
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 // Preload cache for performance

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -1,6 +1,6 @@
 // slide-manager.js - COMPLETE VERSION WITH FADE & ZOOM ANIMATIONS
 
-import { getSlides, getActiveIndex, setActiveIndex, setSlides } from './state-manager.js';
+import { getSlides, getActiveIndex, setActiveIndex, setSlides, recordHistory } from './state-manager.js';
 import { imgState, setTransforms } from './image-manager.js';
 import { clamp } from './utils.js';
 
@@ -767,6 +767,7 @@ export function addSlide() {
     switchToSlide(currentIndex + 1);
     
     console.log('✅ New slide added');
+    recordHistory();
   } catch (error) {
     console.error('Failed to add slide:', error);
   }
@@ -795,6 +796,7 @@ export function duplicateSlide() {
     switchToSlide(currentIndex + 1);
     
     console.log('✅ Slide duplicated');
+    recordHistory();
   } catch (error) {
     console.error('Failed to duplicate slide:', error);
   }
@@ -818,6 +820,7 @@ export function deleteSlide() {
     switchToSlide(newActiveIndex);
     
     console.log('✅ Slide deleted');
+    recordHistory();
   } catch (error) {
     console.error('Failed to delete slide:', error);
   }
@@ -843,6 +846,7 @@ export function handleSlideDuration(value) {
       setSlides([...slides]); // Trigger update
       
       console.log(`✅ Slide duration set to ${durationMs}ms`);
+      recordHistory();
     }
   } catch (error) {
     console.error('Failed to update slide duration:', error);

--- a/state-manager.js
+++ b/state-manager.js
@@ -593,6 +593,7 @@ export const doRedo = () => stateManager.redo();
 export const updateUndoRedoUI = () => stateManager.updateUndoRedoUI();
 export const pushHistory = () => stateManager.pushHistory();
 export { pushHistoryDebounced };
+export const recordHistory = () => stateManager.pushHistoryDebounced();
 
 // State getters
 export const getIsViewer = () => stateManager.isViewer;

--- a/state-manager.test.mjs
+++ b/state-manager.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import stateManager, { setState, getState } from './state-manager.js';
+import stateManager, { setState, getState, setSlides, initializeHistory, pushHistory, doUndo } from './state-manager.js';
 
 // Minimal mock HTMLElement with a circular reference to simulate DOM structure
 class MockHTMLElement {
@@ -64,5 +64,31 @@ const sm = new stateManager.constructor();
   assert.notStrictEqual(result.obj, target.obj);
   console.log('deepMerge bypasses recursion for class instances');
 }
+
+// --- Undo/Redo UI state ---
+stateManager.reset();
+
+const undoBtn = { disabled: true };
+const redoBtn = { disabled: true };
+global.document = {
+  querySelector: (selector) => {
+    if (selector === '#undoBtn') return undoBtn;
+    if (selector === '#redoBtn') return redoBtn;
+    return null;
+  }
+};
+
+initializeHistory();
+setSlides([{ image: null, layers: [], workSize: { w: 800, h: 450 }, durationMs: 3000 }]);
+pushHistory();
+
+assert.strictEqual(undoBtn.disabled, false);
+assert.strictEqual(redoBtn.disabled, true);
+
+doUndo();
+
+assert.strictEqual(undoBtn.disabled, true);
+assert.strictEqual(redoBtn.disabled, false);
+console.log('undo/redo buttons reflect history state');
 
 

--- a/text-manager.js
+++ b/text-manager.js
@@ -1,11 +1,16 @@
 // text-manager.js - COMPLETE FIXED VERSION - All text management functions
 
-import { saveProjectDebounced } from './state-manager.js';
+import { saveProjectDebounced, recordHistory } from './state-manager.js';
 import { generateId } from './utils.js';
 
 // Active layer management
 let activeLayer = null;
 let isLocked = false;
+
+function saveAndRecord() {
+  saveProjectDebounced();
+  recordHistory();
+}
 
 /**
  * Add a new text layer to the work area
@@ -70,7 +75,7 @@ export async function addTextLayer(text = 'New Text', options = {}) {
     
     // Save changes
     setTimeout(() => {
-      saveProjectDebounced();
+      saveAndRecord();
     }, 100);
 
     return textEl;
@@ -100,12 +105,12 @@ function setupTextLayerEvents(textEl) {
 
   // Text input changes
   textEl.addEventListener('input', () => {
-    saveProjectDebounced();
+    saveAndRecord();
   });
 
   // Blur to save changes
   textEl.addEventListener('blur', () => {
-    saveProjectDebounced();
+    saveAndRecord();
   });
 
   // Keyboard shortcuts
@@ -188,7 +193,7 @@ export function deleteTextLayer(textEl) {
     textEl.remove();
     console.log('✅ Text layer deleted');
     
-    saveProjectDebounced();
+    saveAndRecord();
   } catch (error) {
     console.error('Failed to delete text layer:', error);
   }
@@ -233,7 +238,7 @@ export function duplicateActiveLayer() {
     setActiveLayer(newLayer);
 
     console.log('✅ Text layer duplicated');
-    saveProjectDebounced();
+    saveAndRecord();
 
   } catch (error) {
     console.error('Failed to duplicate text layer:', error);
@@ -261,7 +266,7 @@ export function applyFontFamily(fontFamily) {
   
   activeLayer.style.fontFamily = fontFamily;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Font family applied:', fontFamily);
 }
 
@@ -273,7 +278,7 @@ export function applyFontSize(fontSize) {
   
   activeLayer.style.fontSize = fontSize + 'px';
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Font size applied:', fontSize);
 }
 
@@ -285,7 +290,7 @@ export function applyColor(color) {
   
   activeLayer.style.color = color;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Color applied:', color);
 }
 
@@ -300,7 +305,7 @@ export function toggleBold() {
   
   activeLayer.style.fontWeight = newWeight;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Bold toggled:', newWeight);
 }
 
@@ -315,7 +320,7 @@ export function toggleItalic() {
   
   activeLayer.style.fontStyle = newStyle;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Italic toggled:', newStyle);
 }
 
@@ -327,7 +332,7 @@ export function applyTextAlign(alignment) {
   
   activeLayer.style.textAlign = alignment;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Text alignment applied:', alignment);
 }
 
@@ -339,7 +344,7 @@ export function applyTextDecoration(decoration) {
   
   activeLayer.style.textDecoration = decoration;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Text decoration applied:', decoration);
 }
 
@@ -351,7 +356,7 @@ export function applyTextShadow(shadow) {
   
   activeLayer.style.textShadow = shadow;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Text shadow applied:', shadow);
 }
 
@@ -363,7 +368,7 @@ export function applyLetterSpacing(spacing) {
   
   activeLayer.style.letterSpacing = spacing;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Letter spacing applied:', spacing);
 }
 
@@ -375,7 +380,7 @@ export function applyLineHeight(height) {
   
   activeLayer.style.lineHeight = height;
   updateToolbarState();
-  saveProjectDebounced();
+  saveAndRecord();
   console.log('Line height applied:', height);
 }
 
@@ -621,7 +626,7 @@ export function clearAllTextLayers() {
   layers.forEach(layer => layer.remove());
   setActiveLayer(null);
   console.log('✅ All text layers cleared');
-  saveProjectDebounced();
+  saveAndRecord();
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `recordHistory` helper to push undo stack and reuse across managers
- centralize project saves with history recording in text and image managers
- update slide actions to record history and provide undo/redo UI test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bde5767dc8832aace3a5c514e370fe