### PR TITLE
Add underline toggling and toolbar synchronization

### DIFF
--- a/text-manager.js
+++ b/text-manager.js
@@ -429,6 +429,11 @@ export function syncToolbarFromActive() {
     const italicBtn = document.getElementById('italicBtn');
     if (italicBtn) italicBtn.classList.toggle('active', isItalic);
 
+    // Underline
+    const isUnderline = activeLayer.style.textDecoration === 'underline';
+    const underlineBtn = document.getElementById('underlineBtn');
+    if (underlineBtn) underlineBtn.classList.toggle('active', isUnderline);
+
     // Text alignment
     const textAlign = activeLayer.style.textAlign || 'left';
     document.querySelectorAll('[data-align]').forEach(btn => {
@@ -453,6 +458,7 @@ function resetToolbar() {
     const colorInput = document.getElementById('fontColor');
     const boldBtn = document.getElementById('boldBtn');
     const italicBtn = document.getElementById('italicBtn');
+    const underlineBtn = document.getElementById('underlineBtn');
 
     if (fontFamilySelect) fontFamilySelect.value = 'system-ui';
     if (fontSizeInput) fontSizeInput.value = 28;
@@ -460,6 +466,7 @@ function resetToolbar() {
     if (colorInput) colorInput.value = '#ffffff';
     if (boldBtn) boldBtn.classList.remove('active');
     if (italicBtn) italicBtn.classList.remove('active');
+    if (underlineBtn) underlineBtn.classList.remove('active');
 
     document.querySelectorAll('[data-align]').forEach(btn => {
       btn.classList.toggle('active', btn.dataset.align === 'left');
@@ -480,8 +487,8 @@ function updateToolbarState() {
   
   // Enable/disable toolbar controls
   const controls = [
-    'fontFamily', 'fontSize', 'fontColor', 
-    'boldBtn', 'italicBtn', 'deleteLayerBtn'
+    'fontFamily', 'fontSize', 'fontColor',
+    'boldBtn', 'italicBtn', 'underlineBtn', 'deleteLayerBtn'
   ];
 
   controls.forEach(id => {

--- a/text-manager.test.mjs
+++ b/text-manager.test.mjs
@@ -88,7 +88,8 @@ const {
   handleFontColor,
   handleBold,
   handleItalic,
-  handleUnderline
+  handleUnderline,
+  syncToolbarFromActive
 } = tm;
 
 await addTextLayer('Hello');
@@ -168,7 +169,26 @@ assert.strictEqual(layer.style.fontWeight, 'bold');
 handleItalic();
 assert.strictEqual(layer.style.fontStyle, 'italic');
 
+// Underline toggling and toolbar state
+const underlineBtn = document.getElementById('underlineBtn');
+syncToolbarFromActive();
+assert.strictEqual(layer.style.textDecoration, 'none');
+assert.ok(!underlineBtn.classList.contains('active'));
+
 handleUnderline();
 assert.strictEqual(layer.style.textDecoration, 'underline');
+assert.ok(underlineBtn.classList.contains('active'));
+
+handleUnderline();
+assert.strictEqual(layer.style.textDecoration, 'none');
+assert.ok(!underlineBtn.classList.contains('active'));
+
+// Direct sync from style
+layer.style.textDecoration = 'underline';
+syncToolbarFromActive();
+assert.ok(underlineBtn.classList.contains('active'));
+layer.style.textDecoration = 'none';
+syncToolbarFromActive();
+assert.ok(!underlineBtn.classList.contains('active'));
 
 console.log('Text style handlers apply formatting without errors');


### PR DESCRIPTION
## Summary
- Allow toggleUnderline to flip underline formatting
- Sync toolbar underline button state from active layer
- Test underline toggling and button activation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdec28b358832a914f18c0b3d5d700