### PR TITLE
Centralize text handler initialization

### DIFF
--- a/event-handlers.test.mjs
+++ b/event-handlers.test.mjs
@@ -121,6 +121,10 @@ setActiveLayer(layer);
 const manager = new EventHandlersManager();
 manager.setupTextManagementHandlers();
 
+// Text manager initialization shouldn't add extra handlers
+tm.initializeTextManager();
+assert.strictEqual(elements.textDelete.listeners.click.length, 1, 'single delete handler registered');
+
 // Trigger click on delete button
 const deleteBtn = elements.textDelete;
 await deleteBtn.listeners.click[0]({ target: deleteBtn });
@@ -130,4 +134,4 @@ assert.strictEqual(elements.work.children.length, 0, 'layer removed from work');
 assert.strictEqual(getActiveLayer(), null, 'active layer cleared');
 assert.strictEqual(historyCount, 1, 'history updated');
 
-console.log('#textDelete removes active text layer and updates history');
+console.log('Text delete handler fires once and removes active layer');

--- a/text-manager.js
+++ b/text-manager.js
@@ -493,7 +493,7 @@ function updateToolbarState() {
   // Enable/disable toolbar controls
   const controls = [
     'fontFamily', 'fontSize', 'fontColor',
-    'boldBtn', 'italicBtn', 'underlineBtn', 'deleteLayerBtn'
+    'boldBtn', 'italicBtn', 'underlineBtn', 'textDelete'
   ];
 
   controls.forEach(id => {
@@ -678,99 +678,6 @@ export function handleTextZoomOutRange(value) {
 }
 
 /**
- * Setup text management event listeners
- */
-export function setupTextEventListeners() {
-  // Font family
-  const fontFamilySelect = document.getElementById('fontFamily');
-  if (fontFamilySelect) {
-    fontFamilySelect.addEventListener('change', (e) => {
-      handleFontFamily(e.target.value);
-    });
-  }
-
-  // Font size
-  const fontSizeInput = document.getElementById('fontSize');
-  if (fontSizeInput) {
-    fontSizeInput.addEventListener('input', (e) => {
-      handleFontSize(e.target.value);
-    });
-  }
-
-  // Color
-  const colorInput = document.getElementById('fontColor');
-  if (colorInput) {
-    colorInput.addEventListener('change', (e) => {
-      handleFontColor(e.target.value);
-    });
-  }
-
-  // Bold button
-  const boldBtn = document.getElementById('boldBtn');
-  if (boldBtn) {
-    boldBtn.addEventListener('click', handleBold);
-  }
-
-  // Italic button
-  const italicBtn = document.getElementById('italicBtn');
-  if (italicBtn) {
-    italicBtn.addEventListener('click', handleItalic);
-  }
-
-  // Underline button
-  const underlineBtn = document.getElementById('underlineBtn');
-  if (underlineBtn) {
-    underlineBtn.addEventListener('click', handleUnderline);
-  }
-
-  // Alignment buttons
-  document.querySelectorAll('[data-align]').forEach(btn => {
-    btn.addEventListener('click', () => {
-      handleTextAlignChange(btn.dataset.align);
-    });
-  });
-
-  // Delete layer button
-  const deleteLayerBtn = document.getElementById('deleteLayerBtn');
-  if (deleteLayerBtn) {
-    deleteLayerBtn.addEventListener('click', deleteActiveLayer);
-  }
-
-  // Add text layer button
-  const addTextBtn = document.getElementById('addTextBtn');
-  if (addTextBtn) {
-    addTextBtn.addEventListener('click', () => {
-      addTextLayer('New Text');
-    });
-  }
-
-  // Global click to deselect
-  document.addEventListener('click', (e) => {
-    if (!e.target.closest('.layer') && !e.target.closest('.panel-body')) {
-      setActiveLayer(null);
-    }
-  });
-
-  // Keyboard shortcuts
-  document.addEventListener('keydown', (e) => {
-    if (e.target.closest('.layer')) return; // Don't interfere with text editing
-
-    if (e.key === 'Delete' && activeLayer) {
-      e.preventDefault();
-      deleteActiveLayer();
-    } else if (e.key === 'd' && e.ctrlKey && activeLayer) {
-      e.preventDefault();
-      duplicateActiveLayer();
-    } else if (e.key === 't' && e.ctrlKey) {
-      e.preventDefault();
-      addTextLayer('New Text');
-    }
-  });
-
-  console.log('✅ Text event listeners setup complete');
-}
-
-/**
  * Get all text layers
  */
 export function getAllTextLayers() {
@@ -792,14 +699,6 @@ export function clearAllTextLayers() {
  * Initialize text manager
  */
 export function initializeTextManager() {
-  setupTextEventListeners();
   updateToolbarState();
   console.log('✅ Text manager initialized');
-}
-
-// Auto-initialize when DOM is ready
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializeTextManager);
-} else {
-  initializeTextManager();
 }

--- a/text-manager.test.mjs
+++ b/text-manager.test.mjs
@@ -75,6 +75,8 @@ const tm = await import('./text-manager.js');
 const {
   addTextLayer,
   getActiveLayer,
+  setActiveLayer,
+  initializeTextManager,
   handleTextFadeIn,
   handleTextFadeOut,
   handleTextFadeInRange,
@@ -92,8 +94,14 @@ const {
   syncToolbarFromActive
 } = tm;
 
+// Initial toolbar state
+initializeTextManager();
+const deleteBtn = document.getElementById('textDelete');
+assert.ok(deleteBtn.disabled, 'delete button disabled initially');
+
 await addTextLayer('Hello');
 const layer = getActiveLayer();
+assert.ok(!deleteBtn.disabled, 'delete button enabled after adding text');
 
 // Ensure initial UI state
 const fadeInBtn = document.getElementById('textFadeInBtn');
@@ -191,4 +199,9 @@ layer.style.textDecoration = 'none';
 syncToolbarFromActive();
 assert.ok(!underlineBtn.classList.contains('active'));
 
+// Delete button state after deselect
+setActiveLayer(null);
+assert.ok(deleteBtn.disabled, 'delete button disabled after deselecting layer');
+
+console.log('Delete button toggles with text layer selection');
 console.log('Text style handlers apply formatting without errors');


### PR DESCRIPTION
## Summary
- stop text-manager from auto-attaching UI handlers and use `textDelete` id
- route all text-related events through EventHandlersManager, including alignment and global shortcuts
- add tests ensuring single text delete handler and delete button state toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdefb17f84832a8da9ea4568e155fd