### PR TITLE
Prevent dragging text layers while editing

### DIFF
--- a/drag-handlers.js
+++ b/drag-handlers.js
@@ -686,6 +686,7 @@ export class DragHandlersManager {
    */
   attachText(el) {
     if (!el) return;
+    if (el.isContentEditable || el.dataset?.editing === 'true') return;
     el.addEventListener('pointerdown', this._onTextDown);
   }
 
@@ -695,10 +696,11 @@ export class DragHandlersManager {
   _onTextDown(e) {
     const getLocked = this.ctx.getLocked;
     const setActiveLayer = this.ctx.setActiveLayer;
-    
+
     if (getLocked && getLocked()) return;
 
     const t = e.currentTarget;
+    if (t.isContentEditable || t.dataset?.editing === 'true') return;
     if (setActiveLayer) setActiveLayer(t);
     
     this.dragText = {

--- a/drag-handlers.test.mjs
+++ b/drag-handlers.test.mjs
@@ -5,6 +5,10 @@ class MockElement {
   constructor() {
     this.listeners = {};
     this.style = {};
+    this.dataset = {};
+    this.offsetWidth = 0;
+    this.offsetHeight = 0;
+    this.isContentEditable = false;
   }
   addEventListener(type, handler) {
     if (!this.listeners[type]) this.listeners[type] = new Set();
@@ -182,4 +186,26 @@ assert.strictEqual(imgState.shearX, 0);
 assert.strictEqual(imgState.shearY, 0);
 
 console.log('shift-modified drags shear while normal drags scale');
+
+// ----- Text drag ignored when editing -----
+
+const manager4 = new DragHandlersManager();
+manager4.ctx = { getLocked: () => false, setActiveLayer: () => assert.fail('should not set active while editing') };
+const editingEl = {
+  style: { left: '0', top: '0' },
+  offsetWidth: 50,
+  offsetHeight: 20,
+  dataset: { editing: 'true' },
+  isContentEditable: true
+};
+manager4._onTextDown({ currentTarget: editingEl, clientX: 0, clientY: 0 });
+assert.strictEqual(manager4.dragText, null);
+console.log('text dragging ignored while editing');
+
+const manager5 = new DragHandlersManager();
+const elNoHandler = new MockElement();
+elNoHandler.dataset.editing = 'true';
+manager5.attachText(elNoHandler);
+assert.strictEqual(elNoHandler.listenerCount('pointerdown'), 0);
+console.log('attachText skips pointer handlers when editing');
 


### PR DESCRIPTION
## Summary
- Skip attaching pointer handlers to text layers marked as editing
- Ignore text layer pointer downs when element is in edit mode
- Test that text dragging is disabled during editing

## Testing
- ⚠️ `node drag-handlers.test.mjs && ...` *(node not installed in environment; attempted `apt-get update` but repositories returned 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf78f24a8832ab2e931b4f71fef44