### PR TITLE
Add text scale and rotation controls for text layers

### DIFF
--- a/event-handlers.js
+++ b/event-handlers.js
@@ -31,6 +31,7 @@ export class EventHandlersManager {
       this.setupTextSelectionHandlers();
       this.setupTextFadeHandlers();
       this.setupTextZoomHandlers();
+      this.setupTextTransformHandlers();
       this.setupImageManagementHandlers();
       this.setupImageFadeHandlers();
       this.setupImageZoomHandlers();
@@ -238,6 +239,21 @@ export class EventHandlersManager {
     });
 
     import('./text-manager.js').then(({ updateTextZoomUI }) => updateTextZoomUI());
+  }
+
+  /**
+   * Setup text scale/rotate handlers
+   */
+  setupTextTransformHandlers() {
+    this.registerInputHandler('textScale', async (e) => {
+      const { handleTextScale } = await import('./text-manager.js');
+      handleTextScale(e.target.value);
+    });
+
+    this.registerInputHandler('textRotate', async (e) => {
+      const { handleTextRotate } = await import('./text-manager.js');
+      handleTextRotate(e.target.value);
+    });
   }
 
   /**

--- a/event-handlers.test.mjs
+++ b/event-handlers.test.mjs
@@ -23,6 +23,7 @@ function createStubElement(id) {
     attributes: {},
     children: [],
     parent: null,
+    dataset: {},
     setAttribute(k, v) { this.attributes[k] = v; },
     getAttribute(k) { return this.attributes[k]; },
     appendChild(child) { child.parent = this; this.children.push(child); },

--- a/index.html
+++ b/index.html
@@ -146,6 +146,14 @@
             <span id="textZoomOutVal" class="pill">0.0s</span>
           </div>
         </div>
+        <div class="row">
+          <label for="textScale">Scale <small id="textScaleVal" aria-live="polite">100%</small></label>
+          <input id="textScale" type="range" min="10" max="300" value="100">
+        </div>
+        <div class="row">
+          <label for="textRotate">Rotate <small id="textRotateVal" aria-live="polite">0°</small></label>
+          <input id="textRotate" type="range" min="-180" max="180" step="1" value="0">
+        </div>
       </section>
 
       <!-- Style -->

--- a/text-manager.test.mjs
+++ b/text-manager.test.mjs
@@ -99,6 +99,8 @@ const {
   handleTextZoomOut,
   handleTextZoomInRange,
   handleTextZoomOutRange,
+  handleTextScale,
+  handleTextRotate,
   handleFontFamily,
   handleFontSize,
   handleFontColor,
@@ -195,6 +197,28 @@ assert.strictEqual(zoomOutVal.textContent, '0.8s');
 handleTextZoomOutRange(600);
 assert.strictEqual(layer._zoomOutMs, 600);
 assert.strictEqual(zoomOutVal.textContent, '0.6s');
+
+// Scale and rotate handlers
+handleTextScale(150);
+assert.strictEqual(parseFloat(layer.dataset.scale), 1.5);
+assert.ok(layer.style.transform.includes('scale(1.5'));
+assert.strictEqual(document.getElementById('textScale').value, '150');
+assert.strictEqual(document.getElementById('textScaleVal').textContent, '150%');
+
+handleTextRotate(45);
+assert.strictEqual(parseFloat(layer.dataset.rotate), 45);
+assert.ok(layer.style.transform.includes('rotate(45deg)'));
+assert.strictEqual(document.getElementById('textRotate').value, '45');
+assert.strictEqual(document.getElementById('textRotateVal').textContent, '45°');
+
+// Sync controls from existing transform
+layer.dataset.scale = '2';
+layer.dataset.rotate = '-30';
+syncToolbarFromActive();
+assert.strictEqual(document.getElementById('textScale').value, '200');
+assert.strictEqual(document.getElementById('textScaleVal').textContent, '200%');
+assert.strictEqual(document.getElementById('textRotate').value, '-30');
+assert.strictEqual(document.getElementById('textRotateVal').textContent, '-30°');
 
 // Style handlers
 handleFontFamily('serif');


### PR DESCRIPTION
## Summary
- Add scale and rotate sliders to Text panel
- Apply transform handlers to active text layer and sync toolbar
- Wire up event handlers and tests for transform controls

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bdf85e7d58832aa9d0e54589348399