### PR TITLE
Avoid clamping centers for oversized images

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -219,10 +219,13 @@ export function enforceImageBounds() {
   const r = work.getBoundingClientRect();
   const w = imgState.natW * imgState.scale;
   const h = imgState.natH * imgState.scale;
-  
-  // Keep image center within reasonable bounds
-  imgState.cx = clamp(imgState.cx, w / 2, r.width - w / 2);
-  imgState.cy = clamp(imgState.cy, h / 2, r.height - h / 2);
+  // Only clamp center when the image fits within the work area.
+  // If the image exceeds the work area in both dimensions, preserve
+  // the center so viewer playback matches editing.
+  if (w <= r.width || h <= r.height) {
+    imgState.cx = clamp(imgState.cx, w / 2, r.width - w / 2);
+    imgState.cy = clamp(imgState.cy, h / 2, r.height - h / 2);
+  }
 }
 
 // ENHANCED: Set image transforms with viewer mode support


### PR DESCRIPTION
## Summary
- Only clamp image center coordinates when the scaled image fits within the work area
- Preserve image center when the image exceeds work bounds to keep viewer playback aligned with editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0312374d8832aa60368547a2d5058