### PR TITLE
Align image scaling with fx video

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -64,6 +64,20 @@ function fmtSec(ms) {
   return (ms / 1000).toFixed(1) + 's';
 }
 
+// Helper to compute the scale used by the fx video so images can match it
+export function getFxScale() {
+  const fxVideo = document.getElementById('fxVideo');
+  const work = document.getElementById('work');
+  if (!fxVideo || !work) return 1;
+
+  const videoWidth = fxVideo.videoWidth;
+  const videoHeight = fxVideo.videoHeight;
+  if (!videoWidth || !videoHeight) return 1;
+
+  const workRect = work.getBoundingClientRect();
+  return Math.max(workRect.width / videoWidth, workRect.height / videoHeight);
+}
+
 // ENHANCED: Convert absolute coordinates to percentages for sharing
 export function getImagePositionAsPercentage() {
   if (!imgState.has) return null;
@@ -361,14 +375,13 @@ export async function handleImageUpload(file) {
           
           const r = work.getBoundingClientRect();
 
-          // Set default scale so image fits entirely within work area
-          const scaleToFitWidth = r.width / imgState.natW;
-          const scaleToFitHeight = r.height / imgState.natH;
-
+          // Default scale matches fx video growth but never exceeds image's own size
           const { shearX, shearY } = imgState;
-
-          // Use the smaller scale and avoid upscaling beyond 100%
-          imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
+          imgState.scale = Math.min(
+            getFxScale(),
+            r.width / imgState.natW,
+            r.height / imgState.natH
+          );
           imgState.angle = 0;
           imgState.signX = 1;
           imgState.signY = 1;
@@ -451,13 +464,14 @@ function fallbackToLocalUpload(file) {
       }
       
       const r = work.getBoundingClientRect();
-      
-      // Set default scale so image fits within work area
-      const scaleToFitWidth = r.width / imgState.natW;
-      const scaleToFitHeight = r.height / imgState.natH;
 
+      // Default scale matches fx video growth but never exceeds image's own size
       const { shearX, shearY, signX, signY, flip } = imgState;
-      imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
+      imgState.scale = Math.min(
+        getFxScale(),
+        r.width / imgState.natW,
+        r.height / imgState.natH
+      );
       imgState.angle = 0;
       imgState.cx = r.width / 2;
       imgState.cy = r.height / 2;

--- a/share-manager.js
+++ b/share-manager.js
@@ -8,6 +8,7 @@ import {
   setCurrentProjectId,
   historyState
 } from './state-manager.js';
+import { getFxScale } from './image-manager.js';
 
 // Prefer a canonical viewer origin in production so shared links always open the public viewer.
 // Fallback to current origin if you're already on the viewer.
@@ -86,7 +87,11 @@ async function loadSlideImage(slide) {
           imageData: slide.image
         });
 
-        const defaultScale = Math.min(1, workRect.width / naturalWidth, workRect.height / naturalHeight);
+        const defaultScale = Math.min(
+          getFxScale(),
+          workRect.width / naturalWidth,
+          workRect.height / naturalHeight
+        );
         let finalX, finalY, finalScale = defaultScale;
 
         // Check if we have percentage coordinates (new format)

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -1,7 +1,7 @@
 // slide-manager.js - COMPLETE FIXED VERSION WITH IMAGE PERSISTENCE
 
 import { getSlides, getActiveIndex, setActiveIndex, setSlides, recordHistory, saveProjectDebounced } from './state-manager.js';
-import { imgState, setTransforms, enforceImageBounds, toggleUploadBtn } from './image-manager.js';
+import { imgState, setTransforms, enforceImageBounds, toggleUploadBtn, getFxScale } from './image-manager.js';
 import { clamp } from './utils.js';
 
 // Constants
@@ -357,10 +357,11 @@ class ImageLoader {
           } else {
             // Calculate fit-to-canvas defaults if no saved values
             const workRect = work.getBoundingClientRect();
-            const scaleToFitWidth = workRect.width / imgState.natW;
-            const scaleToFitHeight = workRect.height / imgState.natH;
-            
-            imgState.scale = Math.min(1, scaleToFitWidth, scaleToFitHeight);
+            imgState.scale = Math.min(
+              getFxScale(),
+              workRect.width / imgState.natW,
+              workRect.height / imgState.natH
+            );
             imgState.angle = 0;
             imgState.cx = workRect.width / 2;
             imgState.cy = workRect.height / 2;


### PR DESCRIPTION
## Summary
- add helper `getFxScale` to compute the scale factor used by fx video
- default uploaded images to `Math.min(getFxScale(), workRect.width / natW, workRect.height / natH)` and center them
- ensure slide and viewer image loads use the same scaling when no transform stored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c03f182134832a8d44ad21368f31b1