### PR TITLE
Adjust initial image cover scaling

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -373,21 +373,21 @@ export async function handleImageUpload(file) {
             throw new Error('Invalid image dimensions');
           }
           
-          const r = work.getBoundingClientRect();
+          const workRect = work.getBoundingClientRect();
 
-          // Default scale matches fx video growth but never exceeds image's own size
+          // Initial scale should cover the work area but not exceed the fx video scale
           const { shearX, shearY } = imgState;
-          imgState.scale = Math.min(
-            getFxScale(),
-            r.width / imgState.natW,
-            r.height / imgState.natH
+          const coverScale = Math.max(
+            workRect.width / imgState.natW,
+            workRect.height / imgState.natH
           );
+          imgState.scale = Math.min(getFxScale(), coverScale);
           imgState.angle = 0;
           imgState.signX = 1;
           imgState.signY = 1;
           imgState.flip = false;
-          imgState.cx = r.width / 2;
-          imgState.cy = r.height / 2;
+          imgState.cx = workRect.width / 2;
+          imgState.cy = workRect.height / 2;
           imgState.has = true;
           imgState.shearX = shearX;
           imgState.shearY = shearY;
@@ -463,18 +463,18 @@ function fallbackToLocalUpload(file) {
         throw new Error('Invalid image dimensions');
       }
       
-      const r = work.getBoundingClientRect();
+      const workRect = work.getBoundingClientRect();
 
-      // Default scale matches fx video growth but never exceeds image's own size
+      // Initial scale should cover the work area but not exceed the fx video scale
       const { shearX, shearY, signX, signY, flip } = imgState;
-      imgState.scale = Math.min(
-        getFxScale(),
-        r.width / imgState.natW,
-        r.height / imgState.natH
+      const coverScale = Math.max(
+        workRect.width / imgState.natW,
+        workRect.height / imgState.natH
       );
+      imgState.scale = Math.min(getFxScale(), coverScale);
       imgState.angle = 0;
-      imgState.cx = r.width / 2;
-      imgState.cy = r.height / 2;
+      imgState.cx = workRect.width / 2;
+      imgState.cy = workRect.height / 2;
       imgState.has = true;
       imgState.shearX = shearX;
       imgState.shearY = shearY;

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -355,13 +355,13 @@ class ImageLoader {
             imgState.signY = imageData.signY || 1;
             imgState.flip = imageData.flip || false;
           } else {
-            // Calculate fit-to-canvas defaults if no saved values
+            // Calculate cover scale defaults if no saved values
             const workRect = work.getBoundingClientRect();
-            imgState.scale = Math.min(
-              getFxScale(),
+            const coverScale = Math.max(
               workRect.width / imgState.natW,
               workRect.height / imgState.natH
             );
+            imgState.scale = Math.min(getFxScale(), coverScale);
             imgState.angle = 0;
             imgState.cx = workRect.width / 2;
             imgState.cy = workRect.height / 2;


### PR DESCRIPTION
## Summary
- ensure initial image scale covers work area without exceeding FX video scaling for uploads and slide loads
- keep images centered on the canvas when first loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d82e765c832a9c0ed445b61fe22c