### PR TITLE
Remove redundant image bounds enforcement in slide image loading

### DIFF
--- a/slide-manager.js
+++ b/slide-manager.js
@@ -380,9 +380,6 @@ class ImageLoader {
           }
           
           setTransforms();
-          if (!document.body.classList.contains('viewer')) {
-            enforceImageBounds();
-          }
           toggleUploadBtn();
           
           console.log('Image loaded and state restored from slide data');


### PR DESCRIPTION
## Summary
- Avoid double clamping during image load by removing redundant `enforceImageBounds` call in `loadSlideImage`.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d8d5e27c832aafdbc0fd7097ed1c