### PR TITLE
Preserve slide image transforms on reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs"
+    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs && node share-manager.test.mjs"
   }
 }

--- a/share-manager.js
+++ b/share-manager.js
@@ -62,15 +62,33 @@ async function loadSlideImage(slide) {
         imgState.has = true;
         setTransforms();
 
-        slide.image.cxPercent = (imgState.cx / rect.width) * 100;
-        slide.image.cyPercent = (imgState.cy / rect.height) * 100;
-        slide.image.scale = imgState.scale;
-        slide.image.angle = imgState.angle;
-        slide.image.shearX = imgState.shearX;
-        slide.image.shearY = imgState.shearY;
-        slide.image.signX = imgState.signX;
-        slide.image.signY = imgState.signY;
-        slide.image.flip = imgState.flip;
+        if (slide.image.cxPercent === undefined) {
+          slide.image.cxPercent = (imgState.cx / rect.width) * 100;
+        }
+        if (slide.image.cyPercent === undefined) {
+          slide.image.cyPercent = (imgState.cy / rect.height) * 100;
+        }
+        if (slide.image.scale === undefined) {
+          slide.image.scale = imgState.scale;
+        }
+        if (slide.image.angle === undefined) {
+          slide.image.angle = imgState.angle;
+        }
+        if (slide.image.shearX === undefined) {
+          slide.image.shearX = imgState.shearX;
+        }
+        if (slide.image.shearY === undefined) {
+          slide.image.shearY = imgState.shearY;
+        }
+        if (slide.image.signX === undefined) {
+          slide.image.signX = imgState.signX;
+        }
+        if (slide.image.signY === undefined) {
+          slide.image.signY = imgState.signY;
+        }
+        if (slide.image.flip === undefined) {
+          slide.image.flip = imgState.flip;
+        }
 
       } catch (error) {
         console.error('Error positioning image:', error);

--- a/share-manager.test.mjs
+++ b/share-manager.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert';
+
+function makeEl() {
+  return {
+    style: {},
+    classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
+    appendChild() {},
+    setAttribute() {},
+    remove() {},
+    getBoundingClientRect() { return { left: 0, top: 0, width: 200, height: 100 }; },
+    querySelectorAll() { return []; },
+    querySelector() { return makeEl(); },
+    addEventListener() {},
+    removeEventListener() {},
+    offsetWidth: 0,
+    offsetHeight: 0,
+  };
+}
+
+const userBgEl = {
+  style: {},
+  naturalWidth: 100,
+  naturalHeight: 50,
+  onload: null,
+  onerror: null,
+  set src(v) { this._src = v; if (this.onload) this.onload(); }
+};
+
+const workEl = {
+  getBoundingClientRect() { return { width: 200, height: 100 }; }
+};
+
+const elements = {
+  '#userBg': userBgEl,
+  '#work': workEl,
+  '#userBgWrap': makeEl(),
+  '#bgBox': makeEl()
+};
+
+global.document = {
+  querySelector(sel) { return elements[sel] || makeEl(); },
+  getElementById(id) { return elements['#' + id] || makeEl(); },
+  body: { classList: { contains: () => false, add() {}, remove() {}, toggle() {} } },
+  createElement() { return makeEl(); }
+};
+
+global.window = { addEventListener() {}, removeEventListener() {}, location: { hostname: 'localhost' } };
+global.fetch = async () => ({ ok: true, json: async () => ({}) });
+
+await import('./share-manager.js');
+
+// Test default centering
+const slide1 = { image: { src: 'foo.jpg' } };
+await window.loadSlideImage(slide1);
+assert.strictEqual(Math.round(slide1.image.cxPercent), 50);
+assert.strictEqual(Math.round(slide1.image.cyPercent), 50);
+
+// Test preserving existing transforms
+const slide2 = { image: { src: 'foo.jpg', cxPercent: 10, cyPercent: 20, scale: 0.5, angle: 0.1, shearX: 0.2, shearY: 0.3, signX: -1, signY: 1, flip: true } };
+await window.loadSlideImage(slide2);
+assert.strictEqual(slide2.image.cxPercent, 10);
+assert.strictEqual(slide2.image.cyPercent, 20);
+assert.strictEqual(slide2.image.scale, 0.5);
+assert.strictEqual(slide2.image.angle, 0.1);
+assert.strictEqual(slide2.image.shearX, 0.2);
+assert.strictEqual(slide2.image.shearY, 0.3);
+assert.strictEqual(slide2.image.signX, -1);
+assert.strictEqual(slide2.image.signY, 1);
+assert.strictEqual(slide2.image.flip, true);
+
+console.log('loadSlideImage centers and preserves transforms');


### PR DESCRIPTION
## Summary
- avoid overwriting slide image transform data by only setting defaults in `loadSlideImage` when values are undefined
- cover default centering and transform preservation with new `share-manager` unit test
- run share-manager test in CI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0e125f5dc832a8dc6107ba54c1a2f