### PR TITLE
Sync image coordinates and use percentage data in playback

### DIFF
--- a/drag-handlers.js
+++ b/drag-handlers.js
@@ -1,5 +1,7 @@
 // drag-handlers.js - COMPLETE FIXED VERSION - Fixes the pointer capture release issue
 
+import { syncImageCoordinates } from './image-manager.js';
+
 /**
  * Enhanced Drag Handlers Manager
  * Handles image transforms, text positioning/resizing, snap guides, touch support
@@ -603,6 +605,8 @@ export class DragHandlersManager {
       if (wasMoving) {
         setTimeout(() => {
           if (ctx.writeCurrentSlide) ctx.writeCurrentSlide();
+          // Ensure slide data has synced coordinates
+          syncImageCoordinates(true);
           if (ctx.saveProjectDebounced) ctx.saveProjectDebounced();
         }, 10);
       }

--- a/image-manager.js
+++ b/image-manager.js
@@ -118,8 +118,44 @@ export function setImagePositionFromPercentage(percentageData) {
   imgState.signX = percentageData.signX || 1;
   imgState.signY = percentageData.signY || 1;
   imgState.flip = percentageData.flip || false;
-  
+
   setTransforms();
+}
+
+// ENHANCED: Synchronize current image coordinates back to slide data
+export function syncImageCoordinates(force = false) {
+  const slides = getSlides();
+  const activeIndex = getActiveIndex();
+  const slide = slides?.[activeIndex];
+  if (!slide) return;
+
+  const work = document.querySelector('#work');
+  if (!work) return;
+
+  if (!slide.image) slide.image = {};
+
+  const rect = work.getBoundingClientRect();
+  const data = {
+    cx: imgState.cx,
+    cy: imgState.cy,
+    cxPercent: rect.width ? (imgState.cx / rect.width) * 100 : 0,
+    cyPercent: rect.height ? (imgState.cy / rect.height) * 100 : 0,
+    scale: imgState.scale,
+    angle: imgState.angle,
+    shearX: imgState.shearX,
+    shearY: imgState.shearY,
+    signX: imgState.signX,
+    signY: imgState.signY,
+    flip: imgState.flip
+  };
+
+  for (const [key, value] of Object.entries(data)) {
+    if (force || slide.image[key] === undefined) {
+      slide.image[key] = value;
+    }
+  }
+
+  setSlides([...slides]);
 }
 
 // Toggle upload button visibility

--- a/share-manager.js
+++ b/share-manager.js
@@ -8,7 +8,7 @@ import {
   setCurrentProjectId,
   historyState
 } from './state-manager.js';
-import { setImagePositionFromPercentage, setTransforms, imgState } from './image-manager.js';
+import { setImagePositionFromPercentage, setTransforms, imgState, syncImageCoordinates } from './image-manager.js';
 
 // Prefer a canonical viewer origin in production so shared links always open the public viewer.
 // Fallback to current origin if you're already on the viewer.
@@ -519,6 +519,9 @@ export async function shareCurrent() {
       console.warn('Could not import slide-manager:', error);
     }
 
+    // Ensure active slide has up-to-date image coordinates
+    syncImageCoordinates(true);
+
     // Small delay allows layout/state microtasks to flush
     await new Promise((resolve) => setTimeout(resolve, 50));
 
@@ -660,6 +663,7 @@ export function applyViewerFromUrl() {
             
             // Load the active slide with enhanced positioning
             await loadSlideImage(data.slides[activeIndex]);
+            syncImageCoordinates();
             
             // Load text layers if present
             if (data.slides[activeIndex].layers) {

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -342,13 +342,32 @@ class ImageLoader {
           imgState.natW = imageData.natW || userBg.naturalWidth;
           imgState.natH = imageData.natH || userBg.naturalHeight;
           imgState.has = true;
-          
-          // Restore transform values or use defaults
-          if (typeof imageData.scale === 'number') {
+
+          const workRect = work.getBoundingClientRect();
+
+          // Prefer percentage-based positioning if available
+          if (imageData.cxPercent !== undefined && imageData.cyPercent !== undefined) {
+            const coverScale = Math.max(
+              workRect.width / imgState.natW,
+              workRect.height / imgState.natH
+            );
+            const scale = typeof imageData.scale === 'number'
+              ? imageData.scale
+              : Math.min(getFxScale(), coverScale);
+            imgState.scale = scale;
+            imgState.angle = imageData.angle || 0;
+            imgState.cx = (imageData.cxPercent / 100) * workRect.width;
+            imgState.cy = (imageData.cyPercent / 100) * workRect.height;
+            imgState.shearX = imageData.shearX || 0;
+            imgState.shearY = imageData.shearY || 0;
+            imgState.signX = imageData.signX || 1;
+            imgState.signY = imageData.signY || 1;
+            imgState.flip = imageData.flip || false;
+          } else if (typeof imageData.scale === 'number') {
             imgState.scale = imageData.scale;
             imgState.angle = imageData.angle || 0;
-            imgState.cx = imageData.cx || (work.getBoundingClientRect().width / 2);
-            imgState.cy = imageData.cy || (work.getBoundingClientRect().height / 2);
+            imgState.cx = imageData.cx || (workRect.width / 2);
+            imgState.cy = imageData.cy || (workRect.height / 2);
             imgState.shearX = imageData.shearX || 0;
             imgState.shearY = imageData.shearY || 0;
             imgState.signX = imageData.signX || 1;
@@ -356,7 +375,6 @@ class ImageLoader {
             imgState.flip = imageData.flip || false;
           } else {
             // Calculate cover scale defaults if no saved values
-            const workRect = work.getBoundingClientRect();
             const coverScale = Math.max(
               workRect.width / imgState.natW,
               workRect.height / imgState.natH


### PR DESCRIPTION
## Summary
- Add `syncImageCoordinates` helper to persist absolute and percentage image data
- Sync image state after drags and before sharing URLs
- Prefer percentage-based coordinates when loading slides for playback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1741515d8832a9ce92722892c4357