### PR TITLE
Use syncImageCoordinates for image transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The editor supports basic background image adjustments:
 - Drag corner handles to resize the background image or bounding box.
 - Hold **Shift** while dragging a corner to shear the background image/bounding box.
 
+## Transform State Ownership
+`image-manager.js` is the single source of truth for background image transforms.
+Other modules should modify the shared `imgState`, call `setTransforms()`, and let it
+sync via `syncImageCoordinates()` rather than writing to `slide.image.*` directly.
+
 ## Backend API
 Start the development server:
 

--- a/drag-handlers.js
+++ b/drag-handlers.js
@@ -450,7 +450,7 @@ export class DragHandlersManager {
     imgState.cy = newCy;
     
     if (enforceImageBounds && !document.body.classList.contains('viewer')) enforceImageBounds();
-    if (setTransforms && !document.body.classList.contains('viewer')) setTransforms();
+    if (setTransforms && !document.body.classList.contains('viewer')) setTransforms(false);
     if (showGuides && this.ctx.enableGuides) {
       showGuides({ v: snapV, h: snapH });
     }
@@ -562,7 +562,7 @@ export class DragHandlersManager {
     }
 
     if (enforceImageBounds && !document.body.classList.contains('viewer')) enforceImageBounds();
-    if (setTransforms && !document.body.classList.contains('viewer')) setTransforms();
+    if (setTransforms && !document.body.classList.contains('viewer')) setTransforms(false);
   }
 
   /**

--- a/main.js
+++ b/main.js
@@ -593,7 +593,7 @@ class InvitationMakerApp {
           imgState.cy = dragState.startCy + dy;
           
           if (enforceImageBounds && !document.body.classList.contains('viewer')) enforceImageBounds();
-          if (setTransforms && !document.body.classList.contains('viewer')) setTransforms();
+          if (setTransforms && !document.body.classList.contains('viewer')) setTransforms(false);
         } catch (error) {
           console.warn('Could not update image position');
         }
@@ -612,6 +612,8 @@ class InvitationMakerApp {
       
       // Save changes
       try {
+        const { syncImageCoordinates } = await import('./image-manager.js');
+        syncImageCoordinates(true);
         const stateModule = await import('./state-manager.js');
         if (stateModule.writeCurrentSlide) stateModule.writeCurrentSlide();
         if (stateModule.saveProjectDebounced) stateModule.saveProjectDebounced();

--- a/share-manager.js
+++ b/share-manager.js
@@ -42,7 +42,7 @@ async function loadSlideImage(slide) {
         imgState.natH = userBgEl.naturalHeight;
 
         if (slide.image.cxPercent !== undefined && slide.image.cyPercent !== undefined) {
-          setImagePositionFromPercentage(slide.image);
+          setImagePositionFromPercentage(slide.image, false);
         } else {
           const defaultScale = Math.min(1, rect.width / imgState.natW, rect.height / imgState.natH);
           imgState.scale = typeof slide.image.scale === 'number' ? slide.image.scale : defaultScale;
@@ -60,35 +60,8 @@ async function loadSlideImage(slide) {
         }
 
         imgState.has = true;
-        setTransforms();
-
-        if (slide.image.cxPercent === undefined) {
-          slide.image.cxPercent = (imgState.cx / rect.width) * 100;
-        }
-        if (slide.image.cyPercent === undefined) {
-          slide.image.cyPercent = (imgState.cy / rect.height) * 100;
-        }
-        if (slide.image.scale === undefined) {
-          slide.image.scale = imgState.scale;
-        }
-        if (slide.image.angle === undefined) {
-          slide.image.angle = imgState.angle;
-        }
-        if (slide.image.shearX === undefined) {
-          slide.image.shearX = imgState.shearX;
-        }
-        if (slide.image.shearY === undefined) {
-          slide.image.shearY = imgState.shearY;
-        }
-        if (slide.image.signX === undefined) {
-          slide.image.signX = imgState.signX;
-        }
-        if (slide.image.signY === undefined) {
-          slide.image.signY = imgState.signY;
-        }
-        if (slide.image.flip === undefined) {
-          slide.image.flip = imgState.flip;
-        }
+        setTransforms(false);
+        syncImageCoordinates(true, slide);
 
       } catch (error) {
         console.error('Error positioning image:', error);

--- a/slide-manager.js
+++ b/slide-manager.js
@@ -314,7 +314,7 @@ class ImageLoader {
       imgState.shearX = 0;
       imgState.shearY = 0;
       if (userBg) userBg.src = '';
-      setTransforms();
+      setTransforms(false);
       return;
     }
 
@@ -405,7 +405,7 @@ class ImageLoader {
         } catch (error) {
           console.error('Error restoring image state:', error);
           imgState.has = false;
-          setTransforms();
+          setTransforms(false);
         }
 
         resolve();
@@ -428,7 +428,7 @@ class ImageLoader {
         }
         
         imgState.has = false;
-        setTransforms();
+        setTransforms(false);
         resolve();
       };
 
@@ -487,7 +487,7 @@ export async function loadSlideIntoDOM(slide) {
     if (slide?.image?.src || slide?.image?.thumb) {
       await imageLoader.loadSlideImage(slide);
     } else {
-      setTransforms();
+      setTransforms(false);
     }
 
     // Create text layers


### PR DESCRIPTION
## Summary
- avoid direct `slide.image.*` mutations by relying on `syncImageCoordinates`
- document that `image-manager.js` owns transform state
- standardize `setTransforms` to optionally sync and skip bounds when requested

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c175d411a8832abeb73adb153a154a