### PR TITLE
refactor: consolidate responsive breakpoints

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -335,79 +335,6 @@ body {
   display: none;
 }
 
-@media (max-width: 599px) {
-  :root {
-    --topbar-h: 56px;
-  }
-
-  .topbar {
-    padding: 8px 12px;
-    gap: 8px;
-  }
-
-  .brand {
-    font-size: 13px;
-    gap: 6px;
-    letter-spacing: 0.1px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .brand .dot {
-    width: 8px;
-    height: 8px;
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
-  }
-
-  .topbar .brand {
-    flex: 1 1 100%;
-    justify-content: center;
-    font-size: 15px;
-  }
-
-  .topbar .grow {
-    display: none;
-  }
-
-  .topbar .iconbtn {
-    height: 36px;
-    padding: 0 14px;
-    border-radius: 10px;
-    font-size: 14px;
-  }
-
-  #topbarToggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: fixed;
-    left: 50%;
-    transform: translateX(-50%);
-    top: calc(var(--topbar-h) - 1px);
-    height: 32px;
-    padding: 0 12px;
-    border-radius: 999px;
-    z-index: 96;
-    border: 1px solid #26334f;
-    background: #0b1630;
-    color: var(--text-primary);
-    font-weight: 800;
-    font-size: 13px;
-    box-shadow: 0 8px 18px rgba(37, 99, 235, 0.18);
-    transition: all var(--transition-fast);
-  }
-  
-  #topbarToggle:hover {
-    box-shadow: 0 8px 24px rgba(37, 99, 235, 0.25);
-    transform: translateX(-50%) translateY(-1px);
-  }
-  
-  .mb-topbar-collapsed .topbar .mb-hide-when-collapsed {
-    display: none !important;
-  }
-}
-
 /* ===== SIDE PANEL ===== */
 .sidepanel {
   position: fixed;
@@ -1477,31 +1404,6 @@ body.viewer .layer:hover {
   outline: none !important;
 }
 
-/* ENHANCED: Mobile viewer positioning optimizations */
-@media (max-width: 768px) {
-  body.viewer .wrap {
-    width: 100vw !important;
-    height: 100vh !important;
-    aspect-ratio: auto !important;
-    border-radius: 0 !important;
-  }
-  
-  body.viewer #work {
-    border-radius: 0 !important;
-  }
-  
-  body.viewer #fxVideo,
-  body.viewer #userBg {
-    border-radius: 0 !important;
-  }
-  
-  body.viewer .rsvp {
-    left: max(8px, var(--safe-left)) !important;
-    right: max(8px, var(--safe-right)) !important;
-    bottom: max(8px, var(--safe-bottom)) !important;
-  }
-}
-
 /* Background upload button */
 #uploadBgBtn {
   position: absolute;
@@ -1576,43 +1478,6 @@ body.preview .handle {
 }
 
 /* ===== MOBILE & TOUCH OPTIMIZATIONS ===== */
-@media (max-width: 768px) {
-  .handle {
-    width: 18px;
-    height: 18px;
-  }
-  
-  .handle.nw { left: -9px; top: -9px; }
-  .handle.ne { right: -9px; top: -9px; }
-  .handle.se { right: -9px; bottom: -9px; }
-  .handle.sw { left: -9px; bottom: -9px; }
-  
-  .handle.rotate {
-    width: 20px;
-    height: 20px;
-    top: -36px;
-  }
-  
-  .layer.text-layer.active:not(.editing)::after {
-    width: 16px;
-    height: 16px;
-    bottom: -4px;
-    right: -4px;
-  }
-  
-  .layer.text-layer:not(.editing)::before {
-    font-size: 11px;
-    padding: 3px 6px;
-    top: -28px;
-  }
-  
-  /* Better touch targets for mobile */
-  .rsvp-btn {
-    height: 48px !important;
-    padding: 0 20px !important;
-    font-size: 16px !important; /* Prevent zoom on iOS */
-  }
-}
 
 /* Touch device optimizations */
 @media (pointer: coarse) {
@@ -1670,15 +1535,77 @@ body.preview .handle {
   }
 }
 
-@media (max-width: 959px) {
+@media (min-width: 600px) and (max-width: 959px) {
+  /* ENHANCED: Mobile viewer positioning optimizations */
+  body.viewer .wrap {
+    width: 100vw !important;
+    height: 100vh !important;
+    aspect-ratio: auto !important;
+    border-radius: 0 !important;
+  }
+
+  body.viewer #work {
+    border-radius: 0 !important;
+  }
+
+  body.viewer #fxVideo,
+  body.viewer #userBg {
+    border-radius: 0 !important;
+  }
+
+  body.viewer .rsvp {
+    left: max(8px, var(--safe-left)) !important;
+    right: max(8px, var(--safe-right)) !important;
+    bottom: max(8px, var(--safe-bottom)) !important;
+  }
+
+  /* ===== MOBILE & TOUCH OPTIMIZATIONS ===== */
+  .handle {
+    width: 18px;
+    height: 18px;
+  }
+
+  .handle.nw { left: -9px; top: -9px; }
+  .handle.ne { right: -9px; top: -9px; }
+  .handle.se { right: -9px; bottom: -9px; }
+  .handle.sw { left: -9px; bottom: -9px; }
+
+  .handle.rotate {
+    width: 20px;
+    height: 20px;
+    top: -36px;
+  }
+
+  .layer.text-layer.active:not(.editing)::after {
+    width: 16px;
+    height: 16px;
+    bottom: -4px;
+    right: -4px;
+  }
+
+  .layer.text-layer:not(.editing)::before {
+    font-size: 11px;
+    padding: 3px 6px;
+    top: -28px;
+  }
+
+  /* Better touch targets for mobile */
+  .rsvp-btn {
+    flex: 1 1 45%;
+    height: 48px !important;
+    font-size: 16px !important;
+    padding: 0 20px !important;
+  }
+
+  /* Responsive design adjustments */
   .sidepanel {
     width: min(88vw, 420px);
   }
-  
+
   .backdrop {
     display: none;
   }
-  
+
   .panel-open .backdrop {
     display: block;
     position: fixed;
@@ -1687,27 +1614,187 @@ body.preview .handle {
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
   }
-  
+
   .row {
     flex-direction: column;
     align-items: stretch;
   }
-  
+
   .row label {
     flex: unset;
     width: auto;
     margin-bottom: 4px;
   }
 
-  .rsvp-btn {
-    flex: 1 1 45%;
-    height: 48px;
-    font-size: 16px;
-    padding: 0 20px;
+  body.panel-open:not(.preview):not(.viewer) .rsvp {
+    opacity: 0.3;
+    pointer-events: none;
+    transform: translateY(10px);
   }
 }
 
 @media (max-width: 599px) {
+  :root {
+    --topbar-h: 56px;
+  }
+
+  .topbar {
+    padding: 8px 12px;
+    gap: 8px;
+  }
+
+  .brand {
+    font-size: 13px;
+    gap: 6px;
+    letter-spacing: 0.1px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .brand .dot {
+    width: 8px;
+    height: 8px;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+  }
+
+  .topbar .brand {
+    flex: 1 1 100%;
+    justify-content: center;
+    font-size: 15px;
+  }
+
+  .topbar .grow {
+    display: none;
+  }
+
+  .topbar .iconbtn {
+    height: 36px;
+    padding: 0 14px;
+    border-radius: 10px;
+    font-size: 14px;
+  }
+
+  #topbarToggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    left: 50%;
+    transform: translateX(-50%);
+    top: calc(var(--topbar-h) - 1px);
+    height: 32px;
+    padding: 0 12px;
+    border-radius: 999px;
+    z-index: 96;
+    border: 1px solid #26334f;
+    background: #0b1630;
+    color: var(--text-primary);
+    font-weight: 800;
+    font-size: 13px;
+    box-shadow: 0 8px 18px rgba(37, 99, 235, 0.18);
+    transition: all var(--transition-fast);
+  }
+
+  #topbarToggle:hover {
+    box-shadow: 0 8px 24px rgba(37, 99, 235, 0.25);
+    transform: translateX(-50%) translateY(-1px);
+  }
+
+  .mb-topbar-collapsed .topbar .mb-hide-when-collapsed {
+    display: none !important;
+  }
+
+  /* ENHANCED: Mobile viewer positioning optimizations */
+  body.viewer .wrap {
+    width: 100vw !important;
+    height: 100vh !important;
+    aspect-ratio: auto !important;
+    border-radius: 0 !important;
+  }
+
+  body.viewer #work {
+    border-radius: 0 !important;
+  }
+
+  body.viewer #fxVideo,
+  body.viewer #userBg {
+    border-radius: 0 !important;
+  }
+
+  body.viewer .rsvp {
+    left: max(8px, var(--safe-left)) !important;
+    right: max(8px, var(--safe-right)) !important;
+    bottom: max(8px, var(--safe-bottom)) !important;
+  }
+
+  /* ===== MOBILE & TOUCH OPTIMIZATIONS ===== */
+  .handle {
+    width: 18px;
+    height: 18px;
+  }
+
+  .handle.nw { left: -9px; top: -9px; }
+  .handle.ne { right: -9px; top: -9px; }
+  .handle.se { right: -9px; bottom: -9px; }
+  .handle.sw { left: -9px; bottom: -9px; }
+
+  .handle.rotate {
+    width: 20px;
+    height: 20px;
+    top: -36px;
+  }
+
+  .layer.text-layer.active:not(.editing)::after {
+    width: 16px;
+    height: 16px;
+    bottom: -4px;
+    right: -4px;
+  }
+
+  .layer.text-layer:not(.editing)::before {
+    font-size: 11px;
+    padding: 3px 6px;
+    top: -28px;
+  }
+
+  /* Better touch targets for mobile */
+  .rsvp-btn {
+    flex: 1 1 45%;
+    height: 48px !important;
+    font-size: 16px !important;
+    padding: 0 20px !important;
+  }
+
+  /* Responsive design adjustments */
+  .sidepanel {
+    width: min(88vw, 420px);
+  }
+
+  .backdrop {
+    display: none;
+  }
+
+  .panel-open .backdrop {
+    display: block;
+    position: fixed;
+    inset: var(--topbar-h) 0 0 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+
+  .row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .row label {
+    flex: unset;
+    width: auto;
+    margin-bottom: 4px;
+  }
+
   .rsvp {
     gap: 6px;
     left: 10px;
@@ -1715,31 +1802,27 @@ body.preview .handle {
     bottom: 10px;
     padding: 6px;
   }
-  
+
   .rsvp-btn {
-    flex: 1 1 45%;
-    height: 48px;
-    font-size: 16px;
-    padding: 0 16px;
     font-weight: 700;
+    padding: 0 16px !important;
   }
-  
+
   body.viewer .rsvp {
     left: max(8px, var(--safe-left));
     right: max(8px, var(--safe-right));
     bottom: max(8px, var(--safe-bottom));
   }
-  
+
   /* Optimize form controls for mobile */
   input[type="text"],
   input[type="email"],
   input[type="password"],
   select {
-    font-size: 16px; /* Prevent zoom on iOS */
+    font-size: 16px;
   }
-}
 
-@media (max-width: 480px) {
+  /* Stack layout for very small phones (formerly 480px) */
   .rsvp {
     flex-direction: column;
     align-items: stretch;
@@ -1748,24 +1831,27 @@ body.preview .handle {
 
   .rsvp-btn {
     width: 100%;
-    height: 48px;
-    font-size: 16px;
-    padding: 0 16px;
+    padding: 0 16px !important;
   }
-  
-  /* Stack form elements vertically */
+
   .preset-grid {
     grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
   }
-  
+
   .slides-strip {
     gap: 4px;
   }
-  
+
   .slide-chip {
     min-width: 36px;
     height: 28px;
     font-size: 12px;
+  }
+
+  body.panel-open:not(.preview):not(.viewer) .rsvp {
+    opacity: 0.3;
+    pointer-events: none;
+    transform: translateY(10px);
   }
 }
 
@@ -1937,15 +2023,6 @@ body.dragging,
 body.resizing {
   user-select: none;
   -webkit-user-select: none;
-}
-
-/* Hide RSVP in editor mode when panel is open on small screens */
-@media (max-width: 959px) {
-  body.panel-open:not(.preview):not(.viewer) .rsvp {
-    opacity: 0.3;
-    pointer-events: none;
-    transform: translateY(10px);
-  }
 }
 
 /* ===== ANIMATIONS ===== */


### PR DESCRIPTION
## Summary
- collapse multiple width media queries into a desktop/tablet/phone structure
- migrate existing responsive rules into their respective blocks

## Testing
- `npm test` *(fails: ReferenceError sessionStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c181c565f0832a9679031395721148