### PR TITLE
feat: enforce landscape orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,13 @@
     </div>
   </div>
 
+  <!-- Rotate device prompt -->
+  <div id="rotateOverlay" class="rotate-overlay" aria-hidden="true">
+    <div class="fs-card">
+      <h2>Please rotate your device</h2>
+    </div>
+  </div>
+
   <div class="backdrop" id="backdrop"></div>
 
   <!-- Side Panel -->

--- a/responsive-manager.js
+++ b/responsive-manager.js
@@ -31,9 +31,11 @@ export class ResponsiveManager {
       this.setupResizeObserver();
       this.setupWindowResizeHandler();
       this.initializeWorkWidth();
-      
+      this.setupOrientationHandling();
+
       this.isInitialized = true;
       console.log('✅ ResponsiveManager initialized');
+      await this.forceLandscape();
       
     } catch (error) {
       console.error('❌ Failed to initialize ResponsiveManager:', error);
@@ -344,13 +346,33 @@ export class ResponsiveManager {
   }
 
   /**
+   * Attempt to lock orientation to landscape on mobile/tablet
+   */
+  async forceLandscape() {
+    const { isMobile, isTablet } = this.checkBreakpoints();
+    const overlay = document.getElementById('rotateOverlay');
+    if ((isMobile || isTablet) && screen.orientation?.lock) {
+      try {
+        await screen.orientation.lock('landscape');
+        overlay?.classList.remove('show');
+      } catch (err) {
+        console.warn('Orientation lock failed', err);
+      }
+    } else if ((isMobile || isTablet) && overlay) {
+      const isLandscape = window.matchMedia('(orientation: landscape)').matches;
+      overlay.classList.toggle('show', !isLandscape);
+    }
+  }
+
+  /**
    * Handle orientation changes (mobile)
    */
   handleOrientationChange() {
+    this.forceLandscape();
     if ('orientation' in screen) {
       const orientation = screen.orientation?.angle;
       console.log('📱 Orientation changed:', orientation);
-      
+
       // Force resize check after orientation change
       setTimeout(() => {
         this.forceResizeCheck();

--- a/styles.css
+++ b/styles.css
@@ -2088,6 +2088,26 @@ body.resizing {
   animation: slideUp 0.3s ease;
 }
 
+/* ===== ROTATE DEVICE OVERLAY ===== */
+.rotate-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 24px;
+  background: linear-gradient(180deg, #0b0b22f0, #0b0b22e6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.rotate-overlay.show {
+  display: flex;
+  animation: fadeIn 0.3s ease;
+}
+
 .fs-card h2 {
   margin: 0.1em 0 0.35em;
   font-size: 1.35rem;


### PR DESCRIPTION
## Summary
- lock orientation to landscape on mobile and tablet devices
- retry orientation lock on rotation and show rotate prompt when unsupported

## Testing
- `npm test` *(fails: sessionStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c1854136d4832abce4d0ecc4d88edc