### PR TITLE
Fix rotated image centering and remove obsolete debug helpers

### DIFF
--- a/image-manager.js
+++ b/image-manager.js
@@ -279,12 +279,19 @@ export function enforceImageBounds() {
   const r = work.getBoundingClientRect();
   const w = imgState.natW * imgState.scale;
   const h = imgState.natH * imgState.scale;
-  // Only clamp center when the image fits within the work area.
+
+  // Account for rotation when determining the visible bounding box.
+  const cos = Math.cos(imgState.angle);
+  const sin = Math.sin(imgState.angle);
+  const rotatedW = Math.abs(w * cos) + Math.abs(h * sin);
+  const rotatedH = Math.abs(w * sin) + Math.abs(h * cos);
+
+  // Only clamp center when the rotated image fits within the work area.
   // If the image exceeds the work area in both dimensions, preserve
   // the center so viewer playback matches editing.
-  if (w <= r.width && h <= r.height) {
-    imgState.cx = clamp(imgState.cx, w / 2, r.width - w / 2);
-    imgState.cy = clamp(imgState.cy, h / 2, r.height - h / 2);
+  if (rotatedW <= r.width && rotatedH <= r.height) {
+    imgState.cx = clamp(imgState.cx, rotatedW / 2, r.width - rotatedW / 2);
+    imgState.cy = clamp(imgState.cy, rotatedH / 2, r.height - rotatedH / 2);
   }
 }
 

--- a/share-manager.js
+++ b/share-manager.js
@@ -627,39 +627,4 @@ if (typeof window !== 'undefined') {
   window.loadSlideImage = loadSlideImage;
   window.showViewerUI = showViewerUI;
   window.showFullscreenPrompt = showFullscreenPrompt;
-  
-  // Emergency fix functions for console debugging
-  window.fixImageCentering = function() {
-    const work = document.querySelector('#work');
-    const userBgWrap = document.querySelector('#userBgWrap');
-    if (work && userBgWrap) {
-      const rect = work.getBoundingClientRect();
-      userBgWrap.style.left = (rect.width / 2) + 'px';
-      userBgWrap.style.top = (rect.height / 2) + 'px';
-      userBgWrap.style.zIndex = '15';
-      console.log('Emergency image centering applied');
-    }
-  };
-  
-  window.debugCurrentPositioning = function() {
-    const work = document.querySelector('#work');
-    const userBgWrap = document.querySelector('#userBgWrap');
-    const fxVideo = document.querySelector('#fxVideo');
-    
-    if (work && userBgWrap && fxVideo) {
-      console.log('Current Positioning Debug:', {
-        workArea: work.getBoundingClientRect(),
-        imageWrapper: userBgWrap.getBoundingClientRect(),
-        fxVideo: fxVideo.getBoundingClientRect(),
-        imageStyles: {
-          left: userBgWrap.style.left,
-          top: userBgWrap.style.top,
-          width: userBgWrap.style.width,
-          height: userBgWrap.style.height,
-          transform: userBgWrap.style.transform,
-          zIndex: userBgWrap.style.zIndex
-        }
-      });
-    }
-  };
 }

--- a/share-manager.test.mjs
+++ b/share-manager.test.mjs
@@ -19,8 +19,8 @@ function makeEl() {
 
 const userBgEl = {
   style: {},
-  naturalWidth: 100,
-  naturalHeight: 50,
+  naturalWidth: 160,
+  naturalHeight: 90,
   onload: null,
   onerror: null,
   set src(v) { this._src = v; if (this.onload) this.onload(); }
@@ -48,6 +48,7 @@ global.window = { addEventListener() {}, removeEventListener() {}, location: { h
 global.fetch = async () => ({ ok: true, json: async () => ({}) });
 
 await import('./share-manager.js');
+const { setTransforms, imgState } = await import('./image-manager.js');
 
 // Test default centering
 const slide1 = { image: { src: 'foo.jpg' } };
@@ -69,3 +70,14 @@ assert.strictEqual(slide2.image.signY, 1);
 assert.strictEqual(slide2.image.flip, true);
 
 console.log('loadSlideImage centers and preserves transforms');
+
+// Test rotation preserves center when image is near the edge
+const slide3 = { image: { src: 'foo.jpg' } };
+await window.loadSlideImage(slide3);
+imgState.cx = 50;
+imgState.cy = 50;
+imgState.angle = Math.PI / 2; // 90 degrees
+setTransforms();
+assert.strictEqual(imgState.cx, 50);
+assert.strictEqual(imgState.cy, 50);
+console.log('rotation preserves center');


### PR DESCRIPTION
## Summary
- Account for rotation in `enforceImageBounds` so images stay centered after rotation
- Drop temporary `fixImageCentering` and `debugCurrentPositioning` helpers from share manager
- Add regression test ensuring rotation preserves image center

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1921dc850832a938061b5580630cc