### PR TITLE
Add RSVP foreign key migration and cleanup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,16 @@ cookie.
   }
 }
 ```
+
+## Database Maintenance
+A foreign key now links `rsvps.customer_id` to `customers.id`. Before applying the migration, use the helper scripts to ensure data integrity:
+
+```bash
+# Report orphan RSVPs (use --purge to delete them)
+node scripts/check-orphan-rsvps.js
+
+# One-time cleanup deleting orphaned RSVPs
+node scripts/cleanup-orphan-rsvps.js
+```
+
+Apply the SQL in `migrations/202405241200_add_rsvps_customer_fk.sql` with your migration tool of choice.

--- a/migrations/202405241200_add_rsvps_customer_fk.sql
+++ b/migrations/202405241200_add_rsvps_customer_fk.sql
@@ -1,0 +1,6 @@
+-- Migration: add foreign key constraint linking rsvps.customer_id to customers.id
+-- Requires that all rsvps rows reference existing customers.
+
+ALTER TABLE rsvps
+ADD CONSTRAINT rsvps_customer_id_fkey
+FOREIGN KEY (customer_id) REFERENCES customers(id);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "type": "module",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs && node share-manager.test.mjs && node image-manager.test.mjs && node responsive-manager.test.mjs && node collapsible-groups.test.mjs"
+    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs && node share-manager.test.mjs && node image-manager.test.mjs && node responsive-manager.test.mjs && node collapsible-groups.test.mjs",
+    "rsvps:check": "node scripts/check-orphan-rsvps.js",
+    "rsvps:cleanup": "node scripts/cleanup-orphan-rsvps.js"
+  },
+  "dependencies": {
+    "pg": "^8.11.0"
   }
 }

--- a/scripts/check-orphan-rsvps.js
+++ b/scripts/check-orphan-rsvps.js
@@ -1,0 +1,35 @@
+import { Client } from 'pg';
+
+async function main() {
+  const purge = process.argv.includes('--purge');
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  const orphanQuery = `
+    SELECT r.*
+    FROM rsvps r
+    LEFT JOIN customers c ON r.customer_id = c.id
+    WHERE c.id IS NULL;
+  `;
+  const { rows } = await client.query(orphanQuery);
+  if (rows.length === 0) {
+    console.log('No orphan RSVPs found.');
+  } else {
+    console.log(`Found ${rows.length} orphan RSVP(s):`);
+    console.table(rows);
+    if (purge) {
+      const del = await client.query(
+        'DELETE FROM rsvps WHERE customer_id NOT IN (SELECT id FROM customers);'
+      );
+      console.log(`Deleted ${del.rowCount} orphan RSVP(s).`);
+    } else {
+      console.log('Run again with --purge to delete these rows.');
+    }
+  }
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error('Integrity check failed:', err);
+  process.exit(1);
+});

--- a/scripts/cleanup-orphan-rsvps.js
+++ b/scripts/cleanup-orphan-rsvps.js
@@ -1,0 +1,16 @@
+import { Client } from 'pg';
+
+async function main() {
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  const result = await client.query(
+    'DELETE FROM rsvps WHERE customer_id NOT IN (SELECT id FROM customers);'
+  );
+  console.log(`Deleted ${result.rowCount} orphan RSVP(s).`);
+  await client.end();
+}
+
+main().catch((err) => {
+  console.error('Cleanup failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add SQL migration introducing a foreign key from `rsvps.customer_id` to `customers.id`
- provide scripts to check for and clean up orphan RSVP rows before migrating
- document migration process and scripts in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c58e5e58a0832ab41b0645588a5093