### PR TITLE
Refactor viewer-mode RSVP styling

### DIFF
--- a/fixed-rsvp-system.js
+++ b/fixed-rsvp-system.js
@@ -537,12 +537,12 @@ export function initializeRsvpSystem() {
   console.log('Initializing RSVP system...');
   setupRsvpHandlers();
   
-  // Ensure RSVP bar is visible in viewer mode
+  // Ensure RSVP bar has viewer styling when in viewer mode
   const body = document.body;
   if (body.classList.contains('viewer')) {
     const rsvpBar = document.getElementById('rsvpBar');
     if (rsvpBar) {
-      rsvpBar.style.display = 'flex';
+      rsvpBar.classList.add('viewer-mode');
       console.log('RSVP bar made visible in viewer mode');
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -1330,24 +1330,24 @@ input[type="color"]:hover {
 /* ===== CRITICAL VIEWER MODE POSITIONING FIXES ===== */
 
 /* ENHANCED: Viewer mode RSVP styling with positioning fixes */
-body.viewer .rsvp,
-body.preview .rsvp,
-.rsvp.viewer-mode {
-  display: flex !important;
-  visibility: visible !important;
-  opacity: 1 !important;
-  position: fixed !important;
-  bottom: max(12px, var(--safe-bottom)) !important;
-  left: max(12px, var(--safe-left)) !important;
-  right: max(12px, var(--safe-right)) !important;
-  z-index: 1200 !important;
-  pointer-events: auto !important;
-  transform: none !important;
-  background: rgba(11, 22, 32, 0.95) !important;
-  backdrop-filter: blur(12px) !important;
-  -webkit-backdrop-filter: blur(12px) !important;
-  border: 1px solid rgba(255, 255, 255, 0.15) !important;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3) !important;
+body.viewer #rsvpBar,
+body.preview #rsvpBar,
+#rsvpBar.viewer-mode {
+  display: flex;
+  visibility: visible;
+  opacity: 1;
+  position: fixed;
+  bottom: max(12px, var(--safe-bottom));
+  left: max(12px, var(--safe-left));
+  right: max(12px, var(--safe-right));
+  z-index: 1200;
+  pointer-events: auto;
+  transform: none;
+  background: rgba(11, 22, 32, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 
 /* CRITICAL: Enhanced fullscreen viewer overrides with positioning fixes */
@@ -1582,7 +1582,9 @@ body.preview .handle {
     border-radius: 0;
   }
 
-  body.viewer.mobile .rsvp {
+  body.viewer #rsvpBar,
+  body.preview #rsvpBar,
+  #rsvpBar.viewer-mode {
     left: max(8px, var(--safe-left));
     right: max(8px, var(--safe-right));
     bottom: max(8px, var(--safe-bottom));

--- a/ui-manager.js
+++ b/ui-manager.js
@@ -213,26 +213,14 @@ function setupViewerRsvp() {
     return;
   }
 
-  // Remove any existing inline styles that might interfere
-  rsvpBar.removeAttribute('style');
-  
-  // Apply viewer mode styles
-  Object.assign(rsvpBar.style, {
-    display: 'flex',
-    position: 'fixed',
-    bottom: 'max(12px, env(safe-area-inset-bottom))',
-    left: 'max(12px, env(safe-area-inset-left))', 
-    right: 'max(12px, env(safe-area-inset-right))',
-    zIndex: '1200',
-    pointerEvents: 'auto',
-    visibility: 'visible',
-    opacity: '1',
-    transform: 'none' // Reset any transforms
-  });
-  
+  // Ensure basic visibility then rely on CSS for positioning
+  rsvpBar.style.display = 'flex';
+  rsvpBar.style.visibility = 'visible';
+  rsvpBar.style.opacity = '1';
+
   // Add viewer class for CSS targeting
   rsvpBar.classList.add('viewer-mode');
-  
+
   console.log('RSVP bar configured for viewer mode');
 }
 


### PR DESCRIPTION
## Summary
- replace `!important` viewer-mode positioning with ID-specific selectors for `#rsvpBar`
- add mobile breakpoint rule for RSVP bar without using `!important`
- rely on CSS for RSVP bar placement and keep JS focused on visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5959a4d5c832ab282597cbb069bfe