### PR TITLE
Normalize text color inputs to hex

### DIFF
--- a/text-manager.js
+++ b/text-manager.js
@@ -1,7 +1,7 @@
 // text-manager.js - Complete implementation with editable text support
 
 import { saveProjectDebounced, recordHistory } from './state-manager.js';
-import { generateId, clamp } from './utils.js';
+import { generateId, clamp, rgbToHex } from './utils.js';
 
 // Active layer management
 let activeLayer = null;
@@ -428,9 +428,10 @@ export function applyFontSize(fontSize) {
 export function applyColor(color) {
   if (!activeLayer) return;
 
-  activeLayer.style.color = color;
+  const hex = rgbToHex(color);
+  activeLayer.style.color = hex;
   updateToolbarState();
-  console.log('Color applied:', color);
+  console.log('Color applied:', hex);
 }
 
 /**
@@ -515,7 +516,7 @@ export function syncToolbarFromActive() {
     if (fontSizeVal) fontSizeVal.textContent = fontSize + 'px';
 
     // Color
-    const color = activeLayer.style.color || '#ffffff';
+    const color = rgbToHex(activeLayer.style.color || '#ffffff');
     const colorInput = document.getElementById('fontColor');
     if (colorInput) colorInput.value = color;
 
@@ -689,7 +690,10 @@ export function handleFontSize(value) {
 }
 
 export function handleFontColor(value) {
-  applyColor(value);
+  const hex = rgbToHex(value);
+  applyColor(hex);
+  const colorInput = document.getElementById('fontColor');
+  if (colorInput) colorInput.value = hex;
   saveProjectDebounced();
 }
 

--- a/text-manager.test.mjs
+++ b/text-manager.test.mjs
@@ -230,6 +230,11 @@ assert.strictEqual(document.getElementById('fontSizeVal').textContent, '30px');
 
 handleFontColor('#ff0000');
 assert.strictEqual(layer.style.color, '#ff0000');
+assert.strictEqual(document.getElementById('fontColor').value, '#ff0000');
+
+handleFontColor('rgb(255,0,0)');
+assert.strictEqual(layer.style.color, '#ff0000');
+assert.strictEqual(document.getElementById('fontColor').value, '#ff0000');
 
 handleBold();
 assert.strictEqual(layer.style.fontWeight, 'bold');


### PR DESCRIPTION
## Summary
- Convert all color handling to use hex values by importing and leveraging `rgbToHex`
- Sanitize color assignments and toolbar synchronization to normalize RGB/hex inputs
- Add regression tests ensuring RGB inputs are normalized to hex in both state and UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c59b236858832abd2766c885d55499