### PR TITLE
feat(auth): add remember-me session persistence

### DIFF
--- a/api-client.test.mjs
+++ b/api-client.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert';
+
+function createStorage() {
+  const store = new Map();
+  return {
+    getItem: key => (store.has(key) ? store.get(key) : null),
+    setItem: (key, value) => { store.set(key, String(value)); },
+    removeItem: key => { store.delete(key); },
+    clear: () => { store.clear(); }
+  };
+}
+
+global.localStorage = createStorage();
+global.sessionStorage = createStorage();
+
+const { APIClient } = await import('./api-client.js');
+
+const fetchStub = async () => ({
+  ok: true,
+  headers: { get: () => 'application/json' },
+  json: async () => ({ token: 'abc123', user: { email: 'user@example.com' } })
+});
+
+// Session-only storage uses sessionStorage
+{
+  const client = new APIClient('http://test', fetchStub);
+  await client.login({ email: 'a', password: 'b', remember: false });
+  assert.ok(sessionStorage.getItem('app_auth_session'));
+  assert.strictEqual(localStorage.getItem('app_auth_session'), null);
+  console.log('session tokens stored in sessionStorage');
+}
+
+// Persistent storage survives reload
+{
+  localStorage.clear();
+  sessionStorage.clear();
+  let client = new APIClient('http://test', fetchStub);
+  await client.login({ email: 'a', password: 'b', remember: true });
+  assert.ok(localStorage.getItem('app_auth_session'));
+  client = new APIClient('http://test', fetchStub);
+  assert.strictEqual(client.token, 'abc123');
+  console.log('persistent token survives reload');
+}
+
+// Expired sessions are cleaned up
+{
+  localStorage.setItem('app_auth_session', JSON.stringify({ token: 'old', lastActivity: Date.now() - (8 * 24 * 60 * 60 * 1000) }));
+  sessionStorage.setItem('app_auth_session', JSON.stringify({ token: 'old', lastActivity: Date.now() - (2 * 24 * 60 * 60 * 1000) }));
+  const client = new APIClient('http://test', fetchStub);
+  assert.strictEqual(client.token, null);
+  assert.strictEqual(localStorage.getItem('app_auth_session'), null);
+  assert.strictEqual(sessionStorage.getItem('app_auth_session'), null);
+  console.log('expired sessions are removed');
+}

--- a/index.html
+++ b/index.html
@@ -30,6 +30,10 @@
           <label for="loginPassword">Password</label>
           <input type="password" id="loginPassword" name="loginPassword" placeholder="Password" required>
         </div>
+        <div class="form-group" style="display:flex;align-items:center;gap:8px;margin-top:8px;">
+          <input type="checkbox" id="rememberMe" name="rememberMe">
+          <label for="rememberMe" style="margin:0;">Remember me</label>
+        </div>
         <button type="submit" class="btn primary" style="width: 100%; margin: 16px 0 8px;">
           Sign In
         </button>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs && node share-manager.test.mjs && node image-manager.test.mjs && node responsive-manager.test.mjs && node collapsible-groups.test.mjs",
+    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs && node share-manager.test.mjs && node image-manager.test.mjs && node responsive-manager.test.mjs && node collapsible-groups.test.mjs && node api-client.test.mjs",
     "rsvps:check": "node scripts/check-orphan-rsvps.js",
     "rsvps:cleanup": "node scripts/cleanup-orphan-rsvps.js"
   },


### PR DESCRIPTION
## Summary
- add "Remember me" checkbox to login modal
- persist auth sessions using localStorage when remembered, otherwise sessionStorage
- guard modal display with session validation and support configurable session lifetimes
- test both storage modes and expired session cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c59bdf318c832aac67e165a24403d6