### PR TITLE
Add breadcrumb navigation and editor routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,14 @@
       <p style="margin-top: 16px; font-size: 12px; color: #94a3b8; text-align: center;">
         Don't have an account? Create one in your backend admin panel.
       </p>
-    </div>
   </div>
+  </div>
+  <nav id="breadcrumbs" class="breadcrumbs" aria-label="Breadcrumb"></nav>
+  <div id="marketplacePage" class="page hidden">
+    <h2>Marketplace</h2>
+    <a href="#" id="skipToEditor" class="btn" style="margin:16px 0;display:inline-block">Skip to blank editor</a>
+  </div>
+  <div id="editorPage" class="page hidden">
   <header class="topbar" id="topbar">
     <div class="brand"> Celesia Animated Invitation</div>
     <div class="grow"></div>
@@ -341,6 +347,7 @@
       </div>
     </div>
   </main>
+  </div>
 
   <script type="module" src="/main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -792,4 +792,63 @@ if (document.readyState === 'loading') {
   setupPanelControls();
 }
 
+const breadcrumbNav = document.getElementById('breadcrumbs');
+const marketplacePage = document.getElementById('marketplacePage');
+const editorPage = document.getElementById('editorPage');
+const authModalEl = document.getElementById('authModal');
+let currentPage = 'login';
+
+function renderBreadcrumbs() {
+  const crumbs = [];
+  if (currentPage === 'login') {
+    crumbs.push('<span>Login</span>');
+  } else if (currentPage === 'marketplace') {
+    crumbs.push('<a href="#" data-nav="login">Login</a>', '<span>Marketplace</span>');
+  } else if (currentPage === 'editor') {
+    crumbs.push('<a href="#" data-nav="login">Login</a>', '<a href="#" data-nav="marketplace">Marketplace</a>', '<span>Editor</span>');
+  }
+  if (breadcrumbNav) {
+    breadcrumbNav.innerHTML = crumbs.join(' &gt; ');
+  }
+}
+
+function showPage(page) {
+  currentPage = page;
+  if (authModalEl) authModalEl.style.display = page === 'login' ? 'flex' : 'none';
+  if (marketplacePage) marketplacePage.classList.toggle('hidden', page !== 'marketplace');
+  if (editorPage) editorPage.classList.toggle('hidden', page !== 'editor');
+  renderBreadcrumbs();
+}
+
+function navigate(page, replace = false) {
+  showPage(page);
+  const method = replace ? 'replaceState' : 'pushState';
+  history[method]({ page }, '', `#${page}`);
+}
+
+window.addEventListener('popstate', (e) => {
+  const page = e.state?.page || 'login';
+  showPage(page);
+});
+
+document.getElementById('loginForm')?.addEventListener('submit', (e) => {
+  e.preventDefault();
+  navigate('marketplace');
+});
+
+document.getElementById('skipToEditor')?.addEventListener('click', (e) => {
+  e.preventDefault();
+  navigate('editor');
+});
+
+breadcrumbNav?.addEventListener('click', (e) => {
+  const link = e.target.closest('a[data-nav]');
+  if (link) {
+    e.preventDefault();
+    navigate(link.getAttribute('data-nav'));
+  }
+});
+
+navigate('login', true);
+
 export { invitationApp };


### PR DESCRIPTION
## Summary
- Add breadcrumb nav and marketplace layout to index.html with a skip-to-editor link
- Implement simple navigation state handling in main.js for login → marketplace → editor flow and browser back support

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a070ccf0832abd058392cb72754c