### PR TITLE
feat: track token purchases and design access

### DIFF
--- a/migrations/202406011200_create_user_tokens_purchases.sql
+++ b/migrations/202406011200_create_user_tokens_purchases.sql
@@ -1,0 +1,13 @@
+-- Adds tables to track token balances and purchase history
+CREATE TABLE IF NOT EXISTS user_tokens (
+  user_id TEXT PRIMARY KEY,
+  tokens INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_purchases (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  amount INTEGER NOT NULL,
+  purchased_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/purchased-design-manager.test.mjs
+++ b/purchased-design-manager.test.mjs
@@ -4,9 +4,15 @@ import { PurchasedDesignManager } from './purchased-design-manager.js';
 // Stub document with minimal DOM escaping capability
 function createElement(tag) {
   return {
+    tagName: tag.toUpperCase(),
     innerHTML: '',
+    children: [],
+    appendChild(child) {
+      this.children.push(child);
+      return child;
+    },
     set textContent(value) {
-      this.innerHTML = value
+      this.innerHTML = String(value)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
@@ -17,7 +23,11 @@ function createElement(tag) {
 }
 
 global.document = {
-  body: { innerHTML: '' },
+  body: {
+    innerHTML: '',
+    children: [],
+    appendChild(el) { this.children.push(el); }
+  },
   createElement
 };
 
@@ -40,3 +50,32 @@ assert.strictEqual(
   '&lt;b&gt;bold &amp; &quot;quotes&quot;&lt;/b&gt;'
 );
 console.log('escapeHtml safely encodes special characters');
+
+// verifyAccess blocks editing when locked
+{
+  document.body.children = [];
+  const m = new PurchasedDesignManager('t');
+  m.customer = { locked: true };
+  m.verifyAccess();
+  assert.ok(m.editingLocked);
+  console.log('verifyAccess blocks editing for locked designs');
+}
+
+// Owned designs expose download and edit buttons and track usage limits
+{
+  document.body.children = [];
+  const m = new PurchasedDesignManager('t');
+  m.customer = {
+    owned: true,
+    usageLimit: 2,
+    usageCount: 0,
+    expiresAt: new Date(Date.now() + 60_000).toISOString()
+  };
+  m.verifyAccess();
+  assert.ok(document.body.children.some((c) => c.id === 'ownershipActions'));
+  assert.ok(!m.editingLocked);
+  m.recordUsage();
+  m.recordUsage();
+  assert.ok(m.editingLocked);
+  console.log('owned designs expose actions and respect usage limits');
+}

--- a/server/database.js
+++ b/server/database.js
@@ -1,0 +1,10 @@
+// server/database.js
+// Simple in-memory data layer for tokens and purchases.
+// In a real application this would connect to a database.
+
+// Map of user id -> token balance
+export const userTokens = new Map();
+
+// Map of user id -> array of purchase records
+// Each record: { amount:number, purchasedAt:string }
+export const userPurchases = new Map();


### PR DESCRIPTION
## Summary
- add in-memory tables for user token balances and purchase history
- verify design access, block editing when locked, and expose download/edit actions
- track usage limits and add SQL migration for tokens and purchases tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a5b2aa48832abdde7060954ff3ff