### PR TITLE
Improve design accessibility and performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
         <div id="vGuide" class="guide v" aria-hidden="true"></div>
         <div id="hGuide" class="guide h" aria-hidden="true"></div>
 
-        <div id="userBgWrap"><img id="userBg" alt=""></div>
+        <div id="userBgWrap"><img id="userBg" alt="User background"></div>
         <video id="fxVideo" autoplay muted loop playsinline>
           <source src="./Comp 1.webm" type="video/webm">
         </video>

--- a/main.js
+++ b/main.js
@@ -941,24 +941,30 @@ function renderDesignGrid(designs) {
   designs.forEach((design) => {
     const card = document.createElement('div');
     card.className = 'design-card';
+    card.tabIndex = 0;
+    card.setAttribute('role', 'button');
+    card.setAttribute('aria-label', `Preview design ${design.title}`);
     const badgeLabel = selectedCategory === 'popular'
       ? 'Popular'
       : selectedCategory === 'recent'
         ? 'New'
         : design.category || 'General';
     card.innerHTML = `
-      <img src="${design.thumbnailUrl}" alt="${design.title}" class="design-thumb">
+      <img src="${design.thumbnailUrl}" alt="${design.title}" class="design-thumb" loading="lazy">
       <div class="design-info">
         <div class="design-title">${design.title}</div>
         <div class="design-meta">
           <span class="badge">${badgeLabel}</span>
           <span class="price-label">${design.premium ? 'Premium' : 'Free'}</span>
         </div>
-      </div>
-      <div class="design-actions">
-        <button class="btn preview-btn">Preview</button>
       </div>`;
-    card.querySelector('.preview-btn')?.addEventListener('click', () => openPreview(design));
+    card.addEventListener('click', () => openPreview(design));
+    card.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openPreview(design);
+      }
+    });
     designGrid.appendChild(card);
   });
 }
@@ -972,6 +978,7 @@ function openPreview(design) {
     const img = document.createElement('img');
     img.src = src;
     img.alt = design.title;
+    img.loading = 'lazy';
     previewSlides.appendChild(img);
   });
   previewModal.classList.remove('hidden');

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,8 @@
   --text-primary: #e5e7eb;
   --text-secondary: #cbd5e1;
   --text-muted: #94a3b8;
+  --card-bg: #1e293b;
+  --card-border: #334155;
   
   /* Effects */
   --ring: 0 0 0 4px rgba(37, 99, 235, 0.25);
@@ -2284,18 +2286,24 @@ body.resizing {
 }
 
 .design-card {
-  background: #0b1630;
-  border: 1px solid #26334f;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 12px;
   overflow: hidden;
   display: flex;
   flex-direction: column;
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+  outline: none;
 }
 
-.design-card:hover {
+.design-card:hover,
+.design-card:focus {
   transform: translateY(-4px);
   box-shadow: var(--shadow-lg);
+}
+
+.design-card:focus {
+  box-shadow: var(--shadow-lg), var(--ring);
 }
 
 .design-thumb {
@@ -2303,6 +2311,12 @@ body.resizing {
   aspect-ratio: 16 / 9;
   object-fit: cover;
   display: block;
+  transition: transform var(--transition-base);
+}
+
+.design-card:hover .design-thumb,
+.design-card:focus .design-thumb {
+  transform: scale(1.05);
 }
 
 .design-info {


### PR DESCRIPTION
## Summary
- add alt text for background and design images
- make design cards keyboard-accessible with lazy-loaded thumbnails
- style cards with CSS variables, focus rings, and hover transitions

## Testing
- `npm test` *(fails: Error: fail, DOMException, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a72c8024832a89ceba68757dc611