### PR TITLE
Add design models and REST API routes with validation

### DIFF
--- a/migrations/202407011200_create_designs_categories.sql
+++ b/migrations/202407011200_create_designs_categories.sql
@@ -1,0 +1,28 @@
+-- Adds tables for designs and categories
+CREATE TABLE IF NOT EXISTS categories (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS designs (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  category_id TEXT REFERENCES categories(id),
+  title TEXT NOT NULL,
+  views INTEGER DEFAULT 0,
+  thumbnail_url TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_tokens (
+  user_id TEXT PRIMARY KEY,
+  tokens INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS user_purchases (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  amount INTEGER NOT NULL,
+  purchased_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/server/database.js
+++ b/server/database.js
@@ -1,10 +1,62 @@
 // server/database.js
-// Simple in-memory data layer for tokens and purchases.
+// Simple in-memory data layer modelling application tables.
 // In a real application this would connect to a database.
 
-// Map of user id -> token balance
+/**
+ * Map of category id -> category record
+ * Each record: { id:string, name:string }
+ */
+export const categories = new Map([
+  ['birthday', { id: 'birthday', name: 'Birthday' }],
+  ['wedding', { id: 'wedding', name: 'Wedding' }]
+]);
+
+/**
+ * Map of design id -> design record
+ * Each record: {
+ *   id:string,
+ *   userId:string,
+ *   title:string,
+ *   category:string,
+ *   views:number,
+ *   thumbnailUrl:string,
+ *   updatedAt:string
+ * }
+ */
+export const designs = new Map([
+  [
+    '1',
+    {
+      id: '1',
+      userId: 'demo',
+      title: 'Sample Birthday Invite',
+      category: 'birthday',
+      views: 150,
+      thumbnailUrl: '/images/birthday-thumb.png',
+      updatedAt: new Date('2024-01-01T12:00:00Z').toISOString()
+    }
+  ],
+  [
+    '2',
+    {
+      id: '2',
+      userId: 'demo',
+      title: 'Wedding Announcement',
+      category: 'wedding',
+      views: 300,
+      thumbnailUrl: '/images/wedding-thumb.png',
+      updatedAt: new Date('2024-02-15T08:30:00Z').toISOString()
+    }
+  ]
+]);
+
+/**
+ * Map of user id -> token balance
+ */
 export const userTokens = new Map();
 
-// Map of user id -> array of purchase records
-// Each record: { amount:number, purchasedAt:string }
+/**
+ * Map of user id -> array of purchase records
+ * Each record: { amount:number, purchasedAt:string }
+ */
 export const userPurchases = new Map();

--- a/server/designs-store.js
+++ b/server/designs-store.js
@@ -2,26 +2,7 @@
 // Simple in-memory storage for user designs.
 // In a real application this would interface with a database.
 
-const designsByUser = {
-  demo: [
-    {
-      id: '1',
-      title: 'Sample Birthday Invite',
-      category: 'Birthday',
-      views: 150,
-      thumbnailUrl: '/images/birthday-thumb.png',
-      updatedAt: new Date('2024-01-01T12:00:00Z').toISOString()
-    },
-    {
-      id: '2',
-      title: 'Wedding Announcement',
-      category: 'Wedding',
-      views: 300,
-      thumbnailUrl: '/images/wedding-thumb.png',
-      updatedAt: new Date('2024-02-15T08:30:00Z').toISOString()
-    }
-  ]
-};
+import { designs } from './database.js';
 
 /**
  * Retrieve designs for the provided user id.
@@ -30,7 +11,7 @@ const designsByUser = {
  * @returns {Promise<Array<{id:string,title:string,thumbnailUrl:string,updatedAt:string,category?:string,views?:number}>>}
  */
 export async function getDesignsByUser(userId, filters = {}) {
-  let results = designsByUser[userId] ?? [];
+  let results = Array.from(designs.values()).filter((d) => d.userId === userId);
   const { category, search } = filters;
 
   if (category && category !== 'popular' && category !== 'recent') {
@@ -52,4 +33,16 @@ export async function getDesignsByUser(userId, filters = {}) {
   }
 
   return results;
+}
+
+/**
+ * Retrieve a single design by id for the provided user id.
+ * @param {string} userId
+ * @param {string} id
+ * @returns {Promise<{id:string,title:string,thumbnailUrl:string,updatedAt:string,category?:string,views?:number}|null>}
+ */
+export async function getDesignById(userId, id) {
+  const design = designs.get(String(id));
+  if (!design || design.userId !== userId) return null;
+  return design;
 }


### PR DESCRIPTION
## Summary
- model designs, categories, user token balances, and purchase history in memory
- expand server with validated purchase logic and design lookup endpoints
- add SQL migration defining designs, categories, user_tokens, and user_purchases tables

## Testing
- `npm test`
- `npm run rsvps:check` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a7e0a67c832aa797149d9a7c84ea