### PR TITLE
Add test coverage for filtering and purchase flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs && node share-manager.test.mjs && node image-manager.test.mjs && node responsive-manager.test.mjs && node collapsible-groups.test.mjs && node api-client.test.mjs",
+    "test": "node drag-handlers.test.mjs && node purchased-design-manager.test.mjs && node ui-manager.test.mjs && node utils.test.mjs && node state-manager.test.mjs && node slide-manager.test.mjs && node text-manager.test.mjs && node event-handlers.test.mjs && node share-manager.test.mjs && node image-manager.test.mjs && node responsive-manager.test.mjs && node collapsible-groups.test.mjs && node api-client.test.mjs && node server/designs-store.test.mjs && node preview-modal.test.mjs && node purchase-flow.test.mjs && node server/integration.test.mjs",
     "rsvps:check": "node scripts/check-orphan-rsvps.js",
     "rsvps:cleanup": "node scripts/cleanup-orphan-rsvps.js"
   },

--- a/preview-modal.test.mjs
+++ b/preview-modal.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+// Extract openPreview and closePreview from main.js
+const src = fs.readFileSync('./main.js', 'utf8');
+const openMatch = src.match(/function openPreview\(design\) {[\s\S]*?}\n/);
+const closeMatch = src.match(/function closePreview\(\) {[\s\S]*?}\n/);
+if (!openMatch || !closeMatch) throw new Error('preview functions not found');
+
+const context = {
+  currentPreviewDesign: null,
+  previewModal: { classList: { removed: [], added: [], remove(c){ this.removed.push(c); }, add(c){ this.added.push(c); } } },
+  previewSlides: { innerHTML: '', children: [], appendChild(el){ this.children.push(el); } },
+  document: {
+    createElement(tag){ return { tagName: tag, src: '', alt: '', loading: '', appendChild(){}, }; }
+  }
+};
+vm.createContext(context);
+vm.runInContext(openMatch[0] + closeMatch[0], context);
+
+// Open preview with multiple slides
+const design = { title: 'Test', slides: ['a.png', 'b.png'] };
+context.openPreview(design);
+assert.strictEqual(context.currentPreviewDesign, design);
+assert.strictEqual(context.previewSlides.children.length, 2);
+assert.deepStrictEqual(context.previewModal.classList.removed, ['hidden']);
+console.log('openPreview populates slides and shows modal');
+
+// Close preview
+context.closePreview();
+assert.strictEqual(context.currentPreviewDesign, null);
+assert.deepStrictEqual(context.previewModal.classList.added, ['hidden']);
+console.log('closePreview hides modal and clears current design');

--- a/purchase-flow.test.mjs
+++ b/purchase-flow.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const src = fs.readFileSync('./main.js', 'utf8');
+
+function extract(name) {
+  let start = src.indexOf(`async function ${name}`);
+  if (start === -1) start = src.indexOf(`function ${name}`);
+  if (start === -1) throw new Error(`${name} not found`);
+  let i = src.indexOf('{', start) + 1;
+  let depth = 1;
+  while (depth > 0 && i < src.length) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+const showSrc = extract('showPurchaseModal');
+const unlockSrc = extract('unlockDesignFlow');
+
+const context = {
+  tokenBalance: 0,
+  tokenBalanceEl: { textContent: '' },
+  purchaseModal: { classList: { removed: [], added: [], remove(c){ this.removed.push(c); }, add(c){ this.added.push(c); } } },
+  purchaseMessage: { textContent: '' },
+  purchaseConfirm: { textContent: '', onclick: null },
+  apiClient: { tokens: 0, async updateTokens(delta){ this.tokens += delta; } },
+  locked: false,
+  unlockCalls: 0
+};
+vm.createContext(context);
+context.refreshTokenBalance = async function(){ context.tokenBalance = context.apiClient.tokens; context.tokenBalanceEl.textContent = `Tokens: ${context.tokenBalance}`; };
+context.setLocked = function(val){ context.locked = val; };
+vm.runInContext(unlockSrc + '\n' + showSrc, context);
+context.unlockDesignFlow = function(){ context.unlockCalls++; };
+
+// Spend flow deducts one token and unlocks editing
+context.apiClient.tokens = 1;
+context.tokenBalance = 1;
+context.locked = true;
+context.showPurchaseModal('spend');
+assert.strictEqual(context.purchaseMessage.textContent, 'Spend 1 token to unlock this design?');
+assert.strictEqual(context.purchaseConfirm.textContent, 'Unlock');
+await context.purchaseConfirm.onclick();
+assert.strictEqual(context.apiClient.tokens, 0);
+assert.strictEqual(context.tokenBalance, 0);
+assert.strictEqual(context.locked, false);
+assert.deepStrictEqual(context.purchaseModal.classList.added, ['hidden']);
+console.log('spend flow deducts token and unlocks design');
+
+// Reset modal state
+context.purchaseModal.classList.added = [];
+context.purchaseModal.classList.removed = [];
+
+// Buy flow purchases tokens and re-runs unlock flow
+context.apiClient.tokens = 0;
+context.tokenBalance = 0;
+context.unlockCalls = 0;
+context.showPurchaseModal('buy');
+assert.strictEqual(context.purchaseMessage.textContent, 'You have no tokens. Purchase 5 tokens?');
+assert.strictEqual(context.purchaseConfirm.textContent, 'Purchase');
+await context.purchaseConfirm.onclick();
+assert.strictEqual(context.apiClient.tokens, 5);
+assert.strictEqual(context.tokenBalance, 5);
+assert.strictEqual(context.unlockCalls, 1);
+assert.deepStrictEqual(context.purchaseModal.classList.added, ['hidden']);
+console.log('buy flow purchases tokens and triggers unlock');

--- a/server/designs-store.test.mjs
+++ b/server/designs-store.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert';
+import { getDesignsByUser } from './designs-store.js';
+import { designs } from './database.js';
+
+// Prepare sample designs for testing
+const userId = 'u1';
+designs.set('a', {
+  id: 'a',
+  userId,
+  title: 'Birthday Bash',
+  category: 'birthday',
+  views: 10,
+  thumbnailUrl: 'a.png',
+  updatedAt: new Date('2024-01-01T00:00:00Z').toISOString()
+});
+designs.set('b', {
+  id: 'b',
+  userId,
+  title: 'Wedding Bells',
+  category: 'wedding',
+  views: 50,
+  thumbnailUrl: 'b.png',
+  updatedAt: new Date('2024-03-01T00:00:00Z').toISOString()
+});
+designs.set('c', {
+  id: 'c',
+  userId,
+  title: 'Recent Party',
+  category: 'birthday',
+  views: 5,
+  thumbnailUrl: 'c.png',
+  updatedAt: new Date('2024-04-01T00:00:00Z').toISOString()
+});
+
+// Category filtering
+{
+  const res = await getDesignsByUser(userId, { category: 'wedding' });
+  assert.deepStrictEqual(res.map(d => d.id), ['b']);
+  console.log('filters designs by category');
+}
+
+// Search filtering
+{
+  const res = await getDesignsByUser(userId, { search: 'party' });
+  assert.deepStrictEqual(res.map(d => d.id), ['c']);
+  console.log('filters designs by search term');
+}
+
+// Popular sorting
+{
+  const res = await getDesignsByUser(userId, { category: 'popular' });
+  assert.deepStrictEqual(res.map(d => d.id), ['b', 'a', 'c']);
+  console.log('sorts designs by popularity');
+}
+
+// Recent sorting
+{
+  const res = await getDesignsByUser(userId, { category: 'recent' });
+  assert.deepStrictEqual(res.map(d => d.id), ['c', 'b', 'a']);
+  console.log('sorts designs by recency');
+}

--- a/server/integration.test.mjs
+++ b/server/integration.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert';
+import { createHmac } from 'node:crypto';
+import { userTokens } from './database.js';
+
+process.env.NODE_ENV = 'test';
+const server = (await import('./index.js')).default;
+
+function makeToken(id){
+  const header = Buffer.from(JSON.stringify({alg:'HS256',typ:'JWT'})).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({sub:id,exp:Math.floor(Date.now()/1000)+3600})).toString('base64url');
+  const sig = createHmac('sha256','dev-secret').update(`${header}.${payload}`).digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
+
+userTokens.set('demo',2);
+await new Promise(res => server.listen(0,res));
+const port = server.address().port;
+const base = `http://localhost:${port}`;
+const token = makeToken('demo');
+const headers = { Authorization: `Bearer ${token}` };
+
+// Marketplace fetch
+let res = await fetch(`${base}/api/designs`, { headers });
+let list = await res.json();
+assert.ok(Array.isArray(list) && list.length >= 1);
+console.log('login to marketplace returns designs');
+
+// Editor fetch
+res = await fetch(`${base}/api/designs/1`, { headers });
+const design = await res.json();
+assert.strictEqual(design.id, '1');
+console.log('navigation to editor fetches design');
+
+// Payment processing stub
+res = await fetch(`${base}/api/purchase`, { method:'POST', headers:{...headers,'Content-Type':'application/json'}, body: JSON.stringify({tokens:-1}) });
+let data = await res.json();
+assert.strictEqual(data.tokens, 1);
+console.log('purchase endpoint deducts token');
+
+// Unauthorized access
+res = await fetch(`${base}/api/designs`);
+assert.strictEqual(res.status, 401);
+console.log('unauthorized access rejected');
+
+// Token tampering
+const badToken = token.slice(0,-1) + 'x';
+res = await fetch(`${base}/api/designs`, { headers:{ Authorization: `Bearer ${badToken}` } });
+assert.strictEqual(res.status, 401);
+console.log('tampered token rejected');
+
+// Injection attempt
+res = await fetch(`${base}/api/designs/1%3BDROP`, { headers });
+assert.strictEqual(res.status, 400);
+console.log('injection attack in path rejected');
+
+server.close();


### PR DESCRIPTION
## Summary
- add unit tests for design filtering
- add tests for preview modal and purchase token flow
- add integration and security tests around server endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a8ff1f54832aafad1bff787a5ac5