### PR TITLE
Add routing and query parameter context to React frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.14",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,53 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter, Routes, Route, useLocation, useParams } from 'react-router-dom';
+import { createContext, useContext, useMemo } from 'react';
+import './App.css';
 
-function App() {
-  const [count, setCount] = useState(0)
+// Context to expose query-string parameters across the app
+const QueryParamsContext = createContext(new URLSearchParams());
 
-  return (
-    <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+export function useQueryParams() {
+  return useContext(QueryParamsContext);
 }
 
-export default App
+function QueryParamsProvider({ children }) {
+  const location = useLocation();
+  const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  return (
+    <QueryParamsContext.Provider value={params}>
+      {children}
+    </QueryParamsContext.Provider>
+  );
+}
+
+// Placeholder components for the two main routes
+function Marketplace() {
+  return <div>Marketplace</div>;
+}
+
+function Editor() {
+  const { token: tokenParam } = useParams();
+  const query = useQueryParams();
+  // Token can come from either the route param or query string
+  const token = tokenParam || query.get('token');
+  const view = query.get('view');
+  return (
+    <div>
+      Editor
+      {token && <span> Token: {token}</span>}
+      {view && <span> View: {view}</span>}
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <QueryParamsProvider>
+        <Routes>
+          <Route path="/" element={<Marketplace />} />
+          <Route path="/editor/:token?" element={<Editor />} />
+        </Routes>
+      </QueryParamsProvider>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,8 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.jsx'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+  <App />
+);


### PR DESCRIPTION
## Summary
- Set up React Router with marketplace and editor routes
- Provide query-string access via context for `view` and `token` params
- Render the new App component from `main.jsx`

## Testing
- `npm test` *(fails: InvalidCharacterError & preview-modal SyntaxError)*
- `npm --prefix frontend install` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b2735778832a9b55e294c017975f