### PR TITLE
feat: add react components and context

### DIFF
--- a/docs/legacy-modules.md
+++ b/docs/legacy-modules.md
@@ -1,0 +1,39 @@
+# Legacy Module Overview
+
+This document summarizes key exports and DOM operations in legacy modules
+prior to the React refactor.
+
+## auth-ui-manager.js
+- **Exports**: `AuthUIManager` class with methods like `initialize`, `logout`,
+  `showModal`, `hideModal`, `validateEmailInput`, `checkSession`, etc.
+- **DOM Usage**:
+  - `document.getElementById` to retrieve modal and form elements.
+  - `addEventListener` on forms, modal backdrop and document for user
+    interactions.
+  - Direct manipulation of element classes and styles to show/hide the modal
+    and provide validation feedback.
+
+## slide-manager.js
+- **Exports**: numerous functions including `playSlides`, `stopSlides`,
+  `switchToSlide`, `previousSlide`, `nextSlide`, `resetOpacities`, and
+  `destroySlideManager`.
+- **DOM Usage**:
+  - `document.querySelector`/`querySelectorAll` to access slide layers and
+    toolbar elements.
+  - `document.getElementById` for slide containers and controls.
+  - Manipulation of element styles and attributes to drive animations and UI
+    updates.
+
+## text-manager.js
+- **Exports**: `enterTextEditMode`, `exitTextEditMode`, `isInEditMode`,
+  `getEditingElement`, `addTextLayer` and various helpers.
+- **DOM Usage**:
+  - `document.getElementById` to locate the work area.
+  - `document.createElement` to build new text layers and `appendChild` to add
+    them to the DOM.
+  - `addEventListener` for click, double‑click and input events on text
+    elements.
+  - Direct style manipulation for editing behavior and positioning.
+
+These notes guided the creation of the new React components which replace the
+imperative DOM logic with stateful React patterns.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,9 @@
 import { BrowserRouter, Routes, Route, useLocation, useParams } from 'react-router-dom';
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
+import AuthModal from './components/AuthModal.jsx';
+import SlidesPanel from './components/SlidesPanel.jsx';
+import TextLayer from './components/TextLayer.jsx';
+import { AppStateProvider, useAppState } from './context/AppStateContext.jsx';
 import './App.css';
 
 // Context to expose query-string parameters across the app
@@ -27,14 +31,26 @@ function Marketplace() {
 function Editor() {
   const { token: tokenParam } = useParams();
   const query = useQueryParams();
-  // Token can come from either the route param or query string
   const token = tokenParam || query.get('token');
   const view = query.get('view');
+  const { selectedSlide, tokenBalance } = useAppState();
+  const [showAuth, setShowAuth] = useState(false);
+
+  const slides = [
+    { id: 1, text: 'First Slide' },
+    { id: 2, text: 'Second Slide' },
+  ];
+
   return (
     <div>
       Editor
       {token && <span> Token: {token}</span>}
       {view && <span> View: {view}</span>}
+      <div>Token Balance: {tokenBalance}</div>
+      <button onClick={() => setShowAuth(true)}>Login</button>
+      <AuthModal isOpen={showAuth} onClose={() => setShowAuth(false)} />
+      <SlidesPanel slides={slides} />
+      <TextLayer initialText={slides[selectedSlide]?.text} />
     </div>
   );
 }
@@ -42,12 +58,14 @@ function Editor() {
 export default function App() {
   return (
     <BrowserRouter>
-      <QueryParamsProvider>
-        <Routes>
-          <Route path="/" element={<Marketplace />} />
-          <Route path="/editor/:token?" element={<Editor />} />
-        </Routes>
-      </QueryParamsProvider>
+      <AppStateProvider>
+        <QueryParamsProvider>
+          <Routes>
+            <Route path="/" element={<Marketplace />} />
+            <Route path="/editor/:token?" element={<Editor />} />
+          </Routes>
+        </QueryParamsProvider>
+      </AppStateProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/AuthModal.jsx
+++ b/frontend/src/components/AuthModal.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { useAppState } from '../context/AppStateContext.jsx';
+
+export default function AuthModal({ isOpen, onClose }) {
+  const { setTokenBalance } = useAppState();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    // Placeholder for real API call
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    setTokenBalance(100); // simulate received balance
+    setIsSubmitting(false);
+    onClose?.();
+  };
+
+  return (
+    <div className="modal-backdrop">
+      <div className="modal">
+        <form onSubmit={handleSubmit}>
+          <h2>Login</h2>
+          <label>
+            Email
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </label>
+          <label>
+            Password
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </label>
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Logging in…' : 'Login'}
+          </button>
+          <button type="button" onClick={onClose}>Close</button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SlidesPanel.jsx
+++ b/frontend/src/components/SlidesPanel.jsx
@@ -1,0 +1,19 @@
+import { useAppState } from '../context/AppStateContext.jsx';
+
+export default function SlidesPanel({ slides = [] }) {
+  const { selectedSlide, setSelectedSlide } = useAppState();
+
+  return (
+    <div className="slides-panel">
+      {slides.map((slide, index) => (
+        <button
+          key={slide.id || index}
+          className={selectedSlide === index ? 'active' : ''}
+          onClick={() => setSelectedSlide(index)}
+        >
+          Slide {index + 1}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/TextLayer.jsx
+++ b/frontend/src/components/TextLayer.jsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+export default function TextLayer({ initialText = '' }) {
+  const [text, setText] = useState(initialText);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleBlur = () => {
+    setIsEditing(false);
+  };
+
+  return (
+    <div
+      className="text-layer"
+      contentEditable={isEditing}
+      suppressContentEditableWarning
+      onClick={() => setIsEditing(true)}
+      onBlur={handleBlur}
+      onInput={(e) => setText(e.currentTarget.textContent)}
+    >
+      {text}
+    </div>
+  );
+}

--- a/frontend/src/context/AppStateContext.jsx
+++ b/frontend/src/context/AppStateContext.jsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useState } from 'react';
+
+const AppStateContext = createContext(null);
+
+export function AppStateProvider({ children }) {
+  const [selectedSlide, setSelectedSlide] = useState(0);
+  const [tokenBalance, setTokenBalance] = useState(0);
+
+  const value = {
+    selectedSlide,
+    setSelectedSlide,
+    tokenBalance,
+    setTokenBalance,
+  };
+
+  return (
+    <AppStateContext.Provider value={value}>
+      {children}
+    </AppStateContext.Provider>
+  );
+}
+
+export function useAppState() {
+  const ctx = useContext(AppStateContext);
+  if (!ctx) {
+    throw new Error('useAppState must be used within an AppStateProvider');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- Document legacy module exports and DOM usage
- Introduce AppState context for shared editor state
- Implement AuthModal, SlidesPanel, and TextLayer React components
- Wire context and components into App

## Testing
- `npm test` *(fails: work element and DOM-related errors)*
- `npm --prefix frontend run build` *(fails: vite missing due to install permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b316b980832a92b02f89a3cc7463