### PR TITLE
Add default slide names and fallback labels

### DIFF
--- a/frontend/components/SlidesPanel.jsx
+++ b/frontend/components/SlidesPanel.jsx
@@ -20,7 +20,7 @@ export default function SlidesPanel() {
         <button onClick={onAdd} style={{ padding: '4px 8px' }}>+ Add</button>
       </div>
       <div style={{ overflowY: 'auto' }}>
-        {slides.map((s) => (
+        {slides.map((s, index) => (
           <button
             key={s.id}
             onClick={() => onSelect(s.id)}
@@ -34,7 +34,7 @@ export default function SlidesPanel() {
               cursor: 'pointer',
             }}
           >
-            {s.name}
+            {s.name || `Slide ${index + 1}`}
           </button>
         ))}
       </div>

--- a/frontend/pages/editor/[[...token]].jsx
+++ b/frontend/pages/editor/[[...token]].jsx
@@ -34,6 +34,7 @@ function EditorContent() {
       setSlides([
         {
           id: 1,
+          name: 'Slide 1',
           image: null,
           layers: [
             { text: 'First Slide', left: 16, top: 16, fontSize: 28, fontFamily: 'system-ui', color: '#ffffff' },
@@ -43,6 +44,7 @@ function EditorContent() {
         },
         {
           id: 2,
+          name: 'Slide 2',
           image: null,
           layers: [
             { text: 'Second Slide', left: 16, top: 16, fontSize: 28, fontFamily: 'system-ui', color: '#ffffff' },


### PR DESCRIPTION
## Summary
- add default names to seeded slides on initial editor load
- display generated labels when slide names are missing

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9828962dc832a8d3a19323ac0258d