### PR TITLE
Add stateful topbar toggle for editor view

### DIFF
--- a/frontend/pages/index.jsx
+++ b/frontend/pages/index.jsx
@@ -19,6 +19,7 @@ export default function MarketplacePage() {
   const [view, setView] = useState('marketplace'); // 'marketplace' | 'editor'
   const [showPreview, setShowPreview] = useState(false);
   const [showPurchase, setShowPurchase] = useState(false);
+  const [isTopbarVisible, setIsTopbarVisible] = useState(true);
 
   useEffect(() => {
     if (!auth.isAuthenticated) setShowAuth(true);
@@ -30,6 +31,24 @@ export default function MarketplacePage() {
       document.body.classList.toggle('panel-open', panelOpen && view === 'editor');
     }
   }, [panelOpen, view]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+
+    const body = document.body;
+    const shouldHideTopbar = view === 'editor' && !isTopbarVisible;
+    body.classList.toggle('topbar-hidden', shouldHideTopbar);
+
+    return () => {
+      body.classList.remove('topbar-hidden');
+    };
+  }, [isTopbarVisible, view]);
+
+  useEffect(() => {
+    if (view !== 'editor') {
+      setIsTopbarVisible(true);
+    }
+  }, [view]);
 
   return (
     <div>
@@ -60,7 +79,16 @@ export default function MarketplacePage() {
         </div>
 
         {/* Mobile topbar toggle (hidden in viewer) */}
-        <button id="topbarToggle" className="iconbtn" aria-expanded="true" aria-label="Collapse top bar">▾</button>
+        <button
+          id="topbarToggle"
+          className="iconbtn"
+          aria-controls="topbar"
+          aria-expanded={isTopbarVisible}
+          aria-label={isTopbarVisible ? 'Collapse top bar' : 'Expand top bar'}
+          onClick={() => setIsTopbarVisible((value) => !value)}
+        >
+          {isTopbarVisible ? '▾' : '▴'}
+        </button>
 
         {/* Fullscreen and rotate overlays */}
         <FullscreenOverlay />

--- a/frontend/styles/styles.css
+++ b/frontend/styles/styles.css
@@ -310,6 +310,22 @@ body {
   background: linear-gradient(180deg, rgba(30, 41, 59, 0.65), rgba(2, 6, 23, 0.35));
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
+  transition: transform var(--transition-base), opacity var(--transition-base);
+}
+
+body.topbar-hidden {
+  --topbar-h: 0px;
+  padding-top: 0;
+}
+
+body.topbar-hidden .topbar {
+  transform: translateY(calc(-100% - 12px));
+  opacity: 0;
+  pointer-events: none;
+}
+
+body.topbar-hidden #topbarToggle {
+  top: 12px;
 }
 
 .topbar .brand {


### PR DESCRIPTION
## Summary
- add React state to control the editor top bar and keep the toggle button in sync
- update the mobile toggle button to drive aria attributes and icon states
- adjust styles to animate hiding the top bar and reclaim layout space when collapsed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c98667a514832aa306eb30a9b6e21c