### PR TITLE
Improve modal accessibility and focus management

### DIFF
--- a/frontend/components/AuthModal.jsx
+++ b/frontend/components/AuthModal.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAppState } from '../context/AppStateContext.jsx';
 import useAuth from '../hooks/useAuth.js';
+import useModalFocusTrap from '../hooks/useModalFocusTrap.js';
 
 export default function AuthModal({ isOpen, onClose }) {
   const { setTokenBalance } = useAppState();
@@ -10,6 +11,7 @@ export default function AuthModal({ isOpen, onClose }) {
   const [remember, setRemember] = useState(false);
   const [error, setError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const modalRef = useModalFocusTrap(isOpen, onClose);
 
   if (!isOpen) return null;
 
@@ -35,6 +37,7 @@ export default function AuthModal({ isOpen, onClose }) {
       role="dialog"
       aria-modal="true"
       aria-labelledby="authTitle"
+      ref={modalRef}
     >
       <div className="auth-card">
         <h2 id="authTitle">Welcome to Invitation Maker</h2>

--- a/frontend/components/PreviewModal.jsx
+++ b/frontend/components/PreviewModal.jsx
@@ -1,10 +1,17 @@
+import useModalFocusTrap from '../hooks/useModalFocusTrap.js';
+
 export default function PreviewModal({ isOpen, onClose, onUseDesign }) {
+  const modalRef = useModalFocusTrap(isOpen, onClose);
+
+  if (!isOpen) return null;
+
   return (
     <div
       id="previewModal"
-      className={`preview-modal${isOpen ? '' : ' hidden'}`}
+      className="preview-modal"
       role="dialog"
       aria-modal="true"
+      ref={modalRef}
     >
       <div className="preview-content">
         <button id="previewClose" className="iconbtn preview-close" aria-label="Close preview" onClick={onClose}>×</button>

--- a/frontend/components/PurchaseModal.jsx
+++ b/frontend/components/PurchaseModal.jsx
@@ -1,10 +1,17 @@
+import useModalFocusTrap from '../hooks/useModalFocusTrap.js';
+
 export default function PurchaseModal({ isOpen, onConfirm, onCancel }) {
+  const modalRef = useModalFocusTrap(isOpen, onCancel);
+
+  if (!isOpen) return null;
+
   return (
     <div
       id="purchaseModal"
-      className={`purchase-modal${isOpen ? '' : ' hidden'}`}
+      className="purchase-modal"
       role="dialog"
       aria-modal="true"
+      ref={modalRef}
     >
       <div className="purchase-content">
         <p id="purchaseMessage">You need tokens to edit this design.</p>

--- a/frontend/hooks/useModalFocusTrap.js
+++ b/frontend/hooks/useModalFocusTrap.js
@@ -1,0 +1,139 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+const getFocusableElements = (container) => {
+  if (!container) return [];
+
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTORS)).filter(
+    (element) =>
+      element instanceof HTMLElement &&
+      !element.hasAttribute('disabled') &&
+      element.getAttribute('aria-hidden') !== 'true' &&
+      element.tabIndex !== -1 &&
+      !element.hidden
+  );
+};
+
+export default function useModalFocusTrap(isOpen, onClose) {
+  const modalRef = useRef(null);
+  const previousActiveElementRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+
+    if (!isOpen) {
+      const previouslyFocused = previousActiveElementRef.current;
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+      return undefined;
+    }
+
+    const modalElement = modalRef.current;
+    if (!modalElement) {
+      return undefined;
+    }
+
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement && activeElement !== document.body) {
+      previousActiveElementRef.current = activeElement;
+    } else {
+      previousActiveElementRef.current = null;
+    }
+
+    const hadTabIndex = modalElement.hasAttribute('tabindex');
+    const previousTabIndex = modalElement.getAttribute('tabindex');
+    if (!hadTabIndex) {
+      modalElement.setAttribute('tabindex', '-1');
+    }
+
+    const focusFirstElement = () => {
+      const focusableElements = getFocusableElements(modalElement);
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus();
+      } else {
+        modalElement.focus();
+      }
+    };
+
+    const focusTimer = setTimeout(focusFirstElement, 0);
+
+    const handleKeyDown = (event) => {
+      if (!modalRef.current) return;
+
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        event.preventDefault();
+        onClose?.();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const focusableElements = getFocusableElements(modalRef.current);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        modalRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const currentFocus = document.activeElement;
+
+      if (event.shiftKey) {
+        if (currentFocus === firstElement || !modalRef.current.contains(currentFocus)) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+      } else if (currentFocus === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    const handleFocusIn = (event) => {
+      if (!modalRef.current) return;
+      if (modalRef.current.contains(event.target)) return;
+
+      const focusableElements = getFocusableElements(modalRef.current);
+      if (focusableElements.length > 0) {
+        focusableElements[0].focus();
+      } else {
+        modalRef.current.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('focusin', handleFocusIn);
+
+    return () => {
+      clearTimeout(focusTimer);
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('focusin', handleFocusIn);
+
+      if (!hadTabIndex) {
+        modalElement.removeAttribute('tabindex');
+      } else if (previousTabIndex !== null) {
+        modalElement.setAttribute('tabindex', previousTabIndex);
+      }
+    };
+  }, [isOpen, onClose]);
+
+  return modalRef;
+}


### PR DESCRIPTION
## Summary
- add a shared `useModalFocusTrap` hook that traps focus, restores the trigger, and closes on Escape
- update modal components to unmount when closed and wire in the focus trap for accessible keyboard navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c98987d6ac832ab90c0fe4db2dccf9