### PR TITLE
Unify slide selection state in app context

### DIFF
--- a/frontend/context/AppStateContext.jsx
+++ b/frontend/context/AppStateContext.jsx
@@ -33,8 +33,6 @@ const initialState = {
   // Work area
   workSize: { w: 800, h: 450 },
 
-  // Keep existing simple app-level bits for compatibility with current pages
-  selectedSlide: 0, // used by frontend/pages/editor/[[...token]].jsx
   tokenBalance: 0,
 };
 
@@ -87,9 +85,6 @@ function reducer(state, action) {
       slides[idx] = { ...slide, layers };
       return { ...state, slides };
     }
-    // Back-compat for current editor page usage
-    case 'SET_SELECTED_SLIDE':
-      return { ...state, selectedSlide: action.value | 0 };
     case 'SET_TOKEN_BALANCE':
       return { ...state, tokenBalance: action.value | 0 };
     default:
@@ -123,8 +118,6 @@ export function AppStateProvider({ children }) {
     updateTextLayer: (layer, patch, index) => dispatch({ type: 'UPDATE_TEXT_LAYER', layer, patch, index }),
     removeTextLayer: (layer, index) => dispatch({ type: 'REMOVE_TEXT_LAYER', layer, index }),
 
-    // Back-compat used by existing Editor page
-    setSelectedSlide: (value) => dispatch({ type: 'SET_SELECTED_SLIDE', value }),
     setTokenBalance: (value) => dispatch({ type: 'SET_TOKEN_BALANCE', value }),
   }), [state]);
 

--- a/frontend/pages/editor/[[...token]].jsx
+++ b/frontend/pages/editor/[[...token]].jsx
@@ -20,8 +20,6 @@ function EditorContent() {
     setSlides,
     activeIndex,
     setActiveIndex,
-    selectedSlide,
-    setSelectedSlide,
     tokenBalance,
   } = useAppState();
   const editorState = useEditorState();
@@ -54,21 +52,8 @@ function EditorContent() {
         },
       ]);
       setActiveIndex(0);
-      setSelectedSlide(0);
     }
-  }, [slides, setSlides, setActiveIndex, setSelectedSlide]);
-
-  // Keep selectedSlide and activeIndex in sync during migration
-  useEffect(() => {
-    if (selectedSlide !== activeIndex) {
-      setActiveIndex(selectedSlide);
-    }
-  }, [selectedSlide, activeIndex, setActiveIndex]);
-  useEffect(() => {
-    if (activeIndex !== selectedSlide) {
-      setSelectedSlide(activeIndex);
-    }
-  }, [activeIndex, selectedSlide, setSelectedSlide]);
+  }, [slides, setSlides, setActiveIndex]);
   
   return (
     <div>


### PR DESCRIPTION
## Summary
- make AppStateContext expose only activeIndex as the slide selection source of truth
- drop the legacy selectedSlide synchronization logic in the editor page

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca9a8cb2fc832abb3a988abe55a658