### PR TITLE
Enforce JWT secret configuration and header validation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -72,7 +72,11 @@ function readBody(req) {
   });
 }
 
-const SECRET = process.env.JWT_SECRET || 'dev-secret';
+const secretFromEnv = process.env.JWT_SECRET;
+if (typeof secretFromEnv !== 'string' || secretFromEnv.length === 0) {
+  throw new Error('JWT_SECRET environment variable must be set');
+}
+const SECRET = secretFromEnv;
 
 function ensureAdmin(req, res) {
   const user = authenticate(req);


### PR DESCRIPTION
## Summary
- require the JWT secret to be provided via environment variables for both the server and auth modules
- add strict JWT header parsing and ensure only HS256 tokens are accepted
- harden JWT verification by rejecting malformed headers, payloads, or signatures

## Testing
- JWT_SECRET=test-secret node - <<'NODE' ... NODE

------
https://chatgpt.com/codex/tasks/task_e_68ca9b72399c832aae44621f8746c6cd