### PR TITLE
Add tests for fullscreen overlay accessibility

### DIFF
--- a/frontend/components/__tests__/FullscreenOverlay.test.jsx
+++ b/frontend/components/__tests__/FullscreenOverlay.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import FullscreenOverlay from '../FullscreenOverlay.jsx';
+
+describe('FullscreenOverlay', () => {
+  it('renders a modal dialog with the expected accessibility attributes', () => {
+    render(<FullscreenOverlay />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'fsTitle');
+  });
+
+  it('displays the enter full screen button', () => {
+    render(<FullscreenOverlay />);
+
+    expect(screen.getByRole('button', { name: 'Enter Full-Screen' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test that renders the FullscreenOverlay component
- verify the dialog exposes the expected accessibility attributes and button label

## Testing
- npm --prefix frontend test -- --runTestsByPath components/__tests__/FullscreenOverlay.test.jsx *(fails: jest binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cabb4ada4c832aa17aa3feccd49f1f