### PR TITLE
Add AuthModal tests for login flows

### DIFF
--- a/frontend/components/__tests__/AuthModal.test.jsx
+++ b/frontend/components/__tests__/AuthModal.test.jsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
+import AuthModal from '../AuthModal.jsx';
+import useAuth from '../../hooks/useAuth.js';
+import { useAppState } from '../../context/AppStateContext.jsx';
+import useModalFocusTrap from '../../hooks/useModalFocusTrap.js';
+
+jest.mock('../../hooks/useAuth.js', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../context/AppStateContext.jsx', () => ({
+  __esModule: true,
+  useAppState: jest.fn(),
+}));
+
+jest.mock('../../hooks/useModalFocusTrap.js', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const loginMock = jest.fn();
+const setTokenBalanceMock = jest.fn();
+
+describe('AuthModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loginMock.mockReset();
+    setTokenBalanceMock.mockReset();
+
+    useAuth.mockReturnValue({ login: loginMock });
+    useAppState.mockReturnValue({ setTokenBalance: setTokenBalanceMock });
+    useModalFocusTrap.mockReturnValue({ current: null });
+  });
+
+  it('does not render when the modal is closed', () => {
+    const { container } = render(<AuthModal isOpen={false} onClose={jest.fn()} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('submits credentials, updates balance, and closes on successful login', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+
+    loginMock.mockResolvedValue({ balance: 25 });
+
+    render(<AuthModal isOpen onClose={onClose} />);
+
+    expect(useModalFocusTrap).toHaveBeenCalledWith(true, onClose);
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'supersecret');
+    await user.click(screen.getByLabelText(/remember me/i));
+
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(loginMock).toHaveBeenCalledTimes(1));
+    expect(loginMock).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'supersecret',
+      remember: true,
+    });
+
+    await waitFor(() => expect(setTokenBalanceMock).toHaveBeenCalledWith(25));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeEnabled();
+  });
+
+  it('shows an error and resets submitting state when login fails', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    let rejectLogin;
+
+    loginMock.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectLogin = reject;
+        })
+    );
+
+    render(<AuthModal isOpen onClose={onClose} />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'supersecret');
+
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /signing in/i })).toBeInTheDocument()
+    );
+
+    await act(async () => {
+      rejectLogin(new Error('Invalid credentials'));
+    });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid credentials');
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeEnabled();
+    expect(setTokenBalanceMock).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated AuthModal test suite that covers closed, success, and failure flows
- mock useAuth, useAppState, and the focus trap hook to control login responses and capture token balance updates
- verify the form interactions update submission state, call setTokenBalance on success, and surface errors on failures

## Testing
- npm test -- AuthModal *(fails: local jest binary unavailable because npm install is blocked by 403 errors from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cabcae41dc832a800a650a10cd75dd