### PR TITLE
Add RotateOverlay rendering test

### DIFF
--- a/frontend/components/__tests__/RotateOverlay.test.jsx
+++ b/frontend/components/__tests__/RotateOverlay.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import RotateOverlay from '../RotateOverlay.jsx';
+
+describe('RotateOverlay', () => {
+  it('renders a hidden overlay containing the rotate message heading', () => {
+    const { container } = render(<RotateOverlay />);
+    const overlay = container.querySelector('#rotateOverlay');
+
+    expect(overlay).not.toBeNull();
+    expect(overlay).toHaveAttribute('aria-hidden', 'true');
+
+    const heading = screen.getByRole('heading', { name: 'Please rotate your device' });
+    expect(overlay).toContainElement(heading);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test that renders the rotate overlay and asserts the hidden attribute and heading text

## Testing
- npm test -- --runTestsByPath components/__tests__/RotateOverlay.test.jsx *(fails: jest binary unavailable because dependencies cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac23540ec832a9bb8509d38be7e42