### PR TITLE
Add Breadcrumbs navigation rendering test

### DIFF
--- a/frontend/components/__tests__/Breadcrumbs.test.jsx
+++ b/frontend/components/__tests__/Breadcrumbs.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import Breadcrumbs from '../Breadcrumbs.jsx';
+
+describe('Breadcrumbs', () => {
+  it('renders a nav with the breadcrumbs class and aria-label', () => {
+    render(<Breadcrumbs />);
+
+    const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
+
+    expect(nav.tagName).toBe('NAV');
+    expect(nav).toHaveClass('breadcrumbs');
+    expect(nav).toHaveAttribute('aria-label', 'Breadcrumb');
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for the Breadcrumbs component that verifies it renders a navigation element with the expected accessibility attributes

## Testing
- npm --prefix frontend test -- Breadcrumbs *(fails: jest binary missing because dependencies cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac53de298832aade05e324fb60802