### PR TITLE
Proxy npm test to frontend suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ npx http-server
 ```
 Then navigate to the provided local URL to explore the app.
 
+## Testing
+Run the Jest suite from the repository root so both frontend and backend contributors use the same entry point:
+
+```bash
+npm test
+# Example: filter to a specific suite
+npm test -- PreviewModal
+```
+
+The root `npm test` command simply proxies to the frontend runner, so backend developers can execute the latest UI checks without switching directories.
+
 ## Orientation Guidance
 Mobile and tablet screens are no longer forced into landscape orientation.
 Instead, when the device is held in portrait, a rotate prompt overlay guides

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "name": "invitation-maker",
     "scripts": {
         "build": "npm --prefix frontend run build",
+        "test": "npm --prefix frontend test",
         "deploy:staging": "npm run build && wrangler pages deploy frontend/out --project-name=invitation-maker",
         "deploy": "npm run build && wrangler pages deploy frontend/out --project-name=invitation-maker-production",
         "start": "node server/index.js"


### PR DESCRIPTION
## Summary
- add a root-level `npm test` script that forwards to the frontend Jest runner
- document the shared testing command in the README so backend contributors use it

## Testing
- npm test -- PreviewModal

------
https://chatgpt.com/codex/tasks/task_e_68cac9d09c50832ab2904abc3c94654d