### PR TITLE
Add ImageLayer tests

### DIFF
--- a/frontend/components/__tests__/ImageLayer.test.jsx
+++ b/frontend/components/__tests__/ImageLayer.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ImageLayer from '../ImageLayer.jsx';
+
+describe('ImageLayer', () => {
+  it('renders wrapper div with expected positioning styles and element id', () => {
+    const element = {
+      id: 'image-123',
+      type: 'image',
+      x: 10,
+      y: 20,
+      width: 300,
+      height: 150,
+      rotation: 45,
+      src: '/example.jpg',
+      fit: 'cover',
+    };
+
+    const { container } = render(<ImageLayer element={element} />);
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveAttribute('data-element-id', element.id);
+    expect(wrapper?.style.left).toBe('10px');
+    expect(wrapper?.style.top).toBe('20px');
+    expect(wrapper?.style.width).toBe('300px');
+    expect(wrapper?.style.height).toBe('150px');
+    expect(wrapper?.style.transform).toBe('rotate(45deg)');
+  });
+
+  it('passes fallback image source and fit style to nested image', () => {
+    const element = {
+      id: 'image-456',
+      type: 'image',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      rotation: 0,
+      src: '',
+      fit: 'contain',
+    };
+
+    const { container } = render(<ImageLayer element={element} />);
+
+    const image = container.querySelector('img');
+    expect(image).toHaveAttribute('src', '/placeholder.jpg');
+    expect(image?.style.objectFit).toBe('contain');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit coverage to verify ImageLayer wrapper positioning styles and element id
- ensure the nested image falls back to the placeholder source and applies the fit mode

## Testing
- npm test -- ImageLayer.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68caca4a6c08832a872fe67927476996