### PR TITLE
Add Topbar interaction test

### DIFF
--- a/frontend/components/__tests__/Topbar.test.jsx
+++ b/frontend/components/__tests__/Topbar.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Topbar from '../Topbar.jsx';
+
+describe('Topbar', () => {
+  it('fires handlers and renders static controls', () => {
+    const onPreviewClick = jest.fn();
+    const onShareClick = jest.fn();
+    const onTogglePanel = jest.fn();
+
+    const { rerender } = render(
+      <Topbar
+        onPreviewClick={onPreviewClick}
+        onShareClick={onShareClick}
+        onTogglePanel={onTogglePanel}
+        panelOpen
+      />
+    );
+
+    const previewButton = screen.getByRole('button', { name: 'Preview' });
+    const shareButton = screen.getByRole('button', { name: 'Share' });
+    const panelButton = screen.getByRole('button', { name: 'Panel' });
+
+    expect(panelButton).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(previewButton);
+    fireEvent.click(shareButton);
+    fireEvent.click(panelButton);
+
+    expect(onPreviewClick).toHaveBeenCalledTimes(1);
+    expect(onShareClick).toHaveBeenCalledTimes(1);
+    expect(onTogglePanel).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Topbar
+        onPreviewClick={onPreviewClick}
+        onShareClick={onShareClick}
+        onTogglePanel={onTogglePanel}
+        panelOpen={false}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Panel' })).toHaveAttribute('aria-expanded', 'false');
+
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
+    expect(screen.getByText('Slide 1/1')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Topbar component test that verifies handler invocations and aria-expanded updates
- confirm undo/redo disabled state and slide label rendering in the new test

## Testing
- npm test -- Topbar

------
https://chatgpt.com/codex/tasks/task_e_68cacbea4014832a90e4c3e0afd186ca