### PR TITLE
Fix hidden overlay queries in tests

### DIFF
--- a/frontend/components/__tests__/FullscreenOverlay.test.jsx
+++ b/frontend/components/__tests__/FullscreenOverlay.test.jsx
@@ -1,11 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import FullscreenOverlay from '../FullscreenOverlay.jsx';
 
 describe('FullscreenOverlay', () => {
   it('renders a modal dialog with the expected accessibility attributes', () => {
     render(<FullscreenOverlay />);
 
-    const dialog = screen.getByRole('dialog');
+    const dialog = screen.getByRole('dialog', { hidden: true });
     expect(dialog).toBeInTheDocument();
     expect(dialog).toHaveAttribute('aria-modal', 'true');
     expect(dialog).toHaveAttribute('aria-labelledby', 'fsTitle');
@@ -14,6 +14,7 @@ describe('FullscreenOverlay', () => {
   it('displays the enter full screen button', () => {
     render(<FullscreenOverlay />);
 
-    expect(screen.getByRole('button', { name: 'Enter Full-Screen' })).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(within(dialog).getByRole('button', { name: 'Enter Full-Screen', hidden: true })).toBeInTheDocument();
   });
 });

--- a/frontend/components/__tests__/RotateOverlay.test.jsx
+++ b/frontend/components/__tests__/RotateOverlay.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import RotateOverlay from '../RotateOverlay.jsx';
 
 describe('RotateOverlay', () => {
@@ -9,7 +9,7 @@ describe('RotateOverlay', () => {
     expect(overlay).not.toBeNull();
     expect(overlay).toHaveAttribute('aria-hidden', 'true');
 
-    const heading = screen.getByRole('heading', { name: 'Please rotate your device' });
+    const heading = within(overlay).getByRole('heading', { name: 'Please rotate your device', hidden: true });
     expect(overlay).toContainElement(heading);
   });
 });


### PR DESCRIPTION
## Summary
- update the fullscreen overlay tests to opt into hidden nodes when locating the dialog and button
- restrict the rotate overlay heading query to the hidden overlay container

## Testing
- npm test *(fails: existing DragHandler test expects finite coordinates but receives NaN)*

------
https://chatgpt.com/codex/tasks/task_e_68cb64a554a0832a945ba461a935c68e