### PR TITLE
Add MyApp context provider test

### DIFF
--- a/frontend/pages/__tests__/MyApp.test.jsx
+++ b/frontend/pages/__tests__/MyApp.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import MyApp from '../_app.jsx';
+import { useAppState } from '../../context/AppStateContext.jsx';
+
+let recordedProps;
+let recordedContext;
+
+function DummyComponent(props) {
+  recordedProps = props;
+  recordedContext = useAppState();
+  return <div data-testid="dummy-component">Dummy component</div>;
+}
+
+describe('MyApp', () => {
+  beforeEach(() => {
+    recordedProps = undefined;
+    recordedContext = undefined;
+  });
+
+  it('renders the child component with provided props and app state context', () => {
+    const pageProps = { message: 'hello world' };
+
+    render(<MyApp Component={DummyComponent} pageProps={pageProps} />);
+
+    expect(screen.getByTestId('dummy-component')).toBeInTheDocument();
+    expect(recordedProps).toEqual(pageProps);
+    expect(recordedContext).toBeDefined();
+    expect(typeof recordedContext.setSlides).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- add a MyApp test component that records its props and context
- verify the child component renders and receives the app state provider

## Testing
- npm test -- MyApp

------
https://chatgpt.com/codex/tasks/task_e_68cbf78ce3f4832aa8191e1ddced2825