### PR TITLE
Fix API client storage guards for SSR contexts

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -43,7 +43,17 @@ if (typeof navigator !== 'undefined') {
 }
 
 if (typeof global.PointerEvent === 'undefined') {
-  class MockPointerEvent extends MouseEvent {
+  const BaseMouseEvent = typeof MouseEvent !== 'undefined'
+    ? MouseEvent
+    : class MockMouseEvent {
+        constructor(type, params = {}) {
+          this.type = type;
+          this.bubbles = params.bubbles ?? false;
+          this.cancelable = params.cancelable ?? false;
+        }
+      };
+
+  class MockPointerEvent extends BaseMouseEvent {
     constructor(type, params = {}) {
       super(type, params);
 

--- a/frontend/services/api-client.js
+++ b/frontend/services/api-client.js
@@ -153,11 +153,18 @@ class APIClient {
   // Save token to active storage
   saveToken(token) {
     try {
+      const localStorageRef = typeof localStorage !== 'undefined' ? localStorage : null;
+      const sessionStorageRef = typeof sessionStorage !== 'undefined' ? sessionStorage : null;
+
       if (token && typeof token === 'string' && this._storage) {
         const sessionData = { token, lastActivity: Date.now() };
         this._storage.setItem(this._storageKey, JSON.stringify(sessionData));
-        const other = this._storage === localStorage ? sessionStorage : localStorage;
-        try { other && other.removeItem(this._storageKey); } catch (_) {}
+        const storagesToClear = [localStorageRef, sessionStorageRef]
+          .filter((storage) => storage && storage !== this._storage);
+
+        for (const storage of storagesToClear) {
+          try { storage.removeItem(this._storageKey); } catch (_) {}
+        }
         this.token = token;
         this._log('Token saved to storage successfully');
       } else {

--- a/frontend/test/services/api-client.node.test.js
+++ b/frontend/test/services/api-client.node.test.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ */
+
+import { APIClient } from '../../services/api-client.js';
+
+const noopFetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+
+describe('APIClient.saveToken in non-browser environments', () => {
+  beforeEach(() => {
+    delete global.localStorage;
+    delete global.sessionStorage;
+  });
+
+  test('does not throw when web storage APIs are unavailable', () => {
+    const client = new APIClient('http://example.com', noopFetch);
+
+    expect(() => client.saveToken('abc123')).not.toThrow();
+    expect(client.token).toBeNull();
+  });
+
+  test('persists using provided storage when browser storage is missing', () => {
+    const client = new APIClient('http://example.com', noopFetch);
+    const store = {};
+    const storage = {
+      setItem: jest.fn((key, value) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn((key) => {
+        delete store[key];
+      }),
+    };
+
+    client._storage = storage;
+
+    expect(() => client.saveToken('token-123')).not.toThrow();
+
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith(client._storageKey, expect.any(String));
+    expect(storage.removeItem).not.toHaveBeenCalled();
+    expect(JSON.parse(store[client._storageKey]).token).toBe('token-123');
+    expect(client.token).toBe('token-123');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid touching browser storage globals in `APIClient.saveToken` when they are unavailable
- provide a resilient PointerEvent mock in Jest setup for non-browser environments
- add a Node-environment Jest test to ensure `saveToken` does not throw without `localStorage`/`sessionStorage`

## Testing
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68cc0d0cb6f4832a8a9c25da13f64287