### PR TITLE
Add role column to users table

### DIFF
--- a/migrations/202407151200_add_user_role.sql
+++ b/migrations/202407151200_add_user_role.sql
@@ -1,0 +1,11 @@
+-- Adds role support to the users table
+ALTER TABLE users
+  ADD COLUMN role TEXT NOT NULL DEFAULT 'user';
+
+-- Ensure all existing users receive the default role value
+UPDATE users
+SET role = 'user'
+WHERE role IS NULL OR role = '';
+
+-- Index role for faster filtering by role in queries
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);

--- a/server/auth.js
+++ b/server/auth.js
@@ -9,6 +9,8 @@ if (typeof secretFromEnv !== 'string' || secretFromEnv.length === 0) {
 }
 const SECRET = secretFromEnv;
 
+export const DEFAULT_USER_ROLE = 'user';
+
 function constantTimeEqual(a = '', b = '') {
   const bufA = Buffer.from(String(a));
   const bufB = Buffer.from(String(b));
@@ -98,7 +100,7 @@ export function authenticate(req) {
   const userId = payload.sub || payload.userId || payload.id;
   if (!userId) throw new Error('Invalid token payload');
   const rawRole = typeof payload.role === 'string' ? payload.role.trim() : '';
-  const role = rawRole || 'user';
+  const role = rawRole || DEFAULT_USER_ROLE;
   return { id: String(userId), role };
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@
 
 import http from 'node:http';
 import { createHmac } from 'node:crypto';
-import { authenticate, authorizeRoles } from './auth.js';
+import { authenticate, authorizeRoles, DEFAULT_USER_ROLE } from './auth.js';
 import { getDesignsByUser, getDesignById } from './designs-store.js';
 import { userTokens, userPurchases, categories, designs } from './database.js';
 import {
@@ -116,7 +116,7 @@ const server = http.createServer(async (req, res) => {
       let userRecord = Array.from(users.values()).find(u => u.username === email);
       if (!userRecord) {
         const id = String(nextUserId++);
-        userRecord = { id, username: email, role: 'user' };
+        userRecord = { id, username: email, role: DEFAULT_USER_ROLE };
         users.set(id, userRecord);
         userTokens.set(id, 5);
         userPurchases.set(id, []);
@@ -126,7 +126,7 @@ const server = http.createServer(async (req, res) => {
       const payload = {
         sub: userRecord.id,
         email,
-        role: storedRole || 'user',
+        role: storedRole || DEFAULT_USER_ROLE,
         exp: Math.floor(Date.now() / 1000) + 60 * 60
       };
       const token = signJwt(payload);
@@ -153,7 +153,7 @@ const server = http.createServer(async (req, res) => {
             ? storedProfile.role.trim()
             : '';
         const tokenRole = typeof authUser.role === 'string' ? authUser.role.trim() : '';
-        const role = storedRole || tokenRole || 'user';
+        const role = storedRole || tokenRole || DEFAULT_USER_ROLE;
 
         const username =
           storedProfile && typeof storedProfile.username === 'string'
@@ -189,7 +189,7 @@ const server = http.createServer(async (req, res) => {
         return;
       }
       const id = String(nextUserId++);
-      users.set(id, { id, username, role: role || 'user' });
+      users.set(id, { id, username, role: role || DEFAULT_USER_ROLE });
       userTokens.set(id, 5);
       userPurchases.set(id, []);
       res.writeHead(201, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
- add a migration that introduces the `users.role` column with a default, backfill, and index to support filtering
- centralize the default user role constant and apply it when creating, authenticating, and returning user records on the server

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc2558ae84832a95ba49a67f342079