### PR TITLE
Add marketplace data fetching and role-aware rendering

### DIFF
--- a/frontend/components/Marketplace.jsx
+++ b/frontend/components/Marketplace.jsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import useAuth from '../hooks/useAuth.js';
 
 const CATEGORY_OPTIONS = [
   { id: '', label: 'All' },
@@ -10,9 +11,143 @@ const CATEGORY_OPTIONS = [
   { id: 'Wedding', label: 'Wedding' },
 ];
 
+const MARKETPLACE_ROLE_ALIASES = new Map([
+  ['user', 'consumer'],
+]);
+
+function normalizeRole(role) {
+  const normalized = typeof role === 'string' ? role.trim().toLowerCase() : '';
+  if (!normalized) {
+    return 'consumer';
+  }
+  return MARKETPLACE_ROLE_ALIASES.get(normalized) || normalized;
+}
+
+function createCacheKey(role, category, search) {
+  return [role || 'consumer', category || '', search || ''].join('::');
+}
+
+function toDesignerName(listing) {
+  const name = listing?.designer?.displayName;
+  return typeof name === 'string' ? name : '';
+}
+
+function extractFlagEntries(flags) {
+  if (!flags || typeof flags !== 'object') return [];
+  return Object.entries(flags).filter(([, value]) => {
+    if (typeof value === 'boolean') return value;
+    return value !== null && value !== undefined && value !== '';
+  });
+}
+
+function formatConversionRate(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return `${Math.round(numeric * 100)}%`;
+}
+
 export default function Marketplace({ isOpen, onSkipToEditor }) {
   const [activeCategory, setActiveCategory] = useState(CATEGORY_OPTIONS[0].id);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [listingsByKey, setListingsByKey] = useState({});
+  const [loadingByKey, setLoadingByKey] = useState({});
+  const [errorsByKey, setErrorsByKey] = useState({});
   const tabRefs = useRef([]);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const auth = useAuth();
+  const user = auth?.user;
+  const api = auth?.api;
+
+  const normalizedRole = normalizeRole(user?.role);
+  const trimmedSearch = searchTerm.trim();
+  const searchKey = trimmedSearch.toLowerCase();
+  const rawCategory = typeof activeCategory === 'string' ? activeCategory.trim() : '';
+  const categoryKey = rawCategory.toLowerCase();
+  const cacheKey = createCacheKey(normalizedRole, categoryKey, searchKey);
+
+  const currentResult = listingsByKey[cacheKey];
+  const listings = Array.isArray(currentResult?.data) ? currentResult.data : [];
+  const isLoading = Boolean(loadingByKey[cacheKey]);
+  const currentError = errorsByKey[cacheKey] ?? null;
+  const displayRole = normalizedRole.charAt(0).toUpperCase() + normalizedRole.slice(1);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!isOpen) {
+      return undefined;
+    }
+
+    if (!api || typeof api.listMarketplace !== 'function') {
+      return undefined;
+    }
+
+    if (currentResult) {
+      return undefined;
+    }
+
+    const requestKey = cacheKey;
+    const requestCategory = categoryKey || undefined;
+    const requestSearch = trimmedSearch || undefined;
+
+    setLoadingByKey((prev) => ({ ...prev, [requestKey]: true }));
+    setErrorsByKey((prev) => {
+      if (!prev[requestKey]) return prev;
+      const next = { ...prev };
+      delete next[requestKey];
+      return next;
+    });
+
+    (async () => {
+      try {
+        const response = await api.listMarketplace({
+          role: normalizedRole,
+          category: requestCategory,
+          search: requestSearch,
+        });
+
+        if (cancelled || !isMountedRef.current) return;
+
+        const normalizedResponse = {
+          role: typeof response?.role === 'string' ? response.role : normalizedRole,
+          data: Array.isArray(response?.data) ? response.data : [],
+        };
+
+        setListingsByKey((prev) => ({
+          ...prev,
+          [requestKey]: normalizedResponse,
+        }));
+      } catch (error) {
+        if (cancelled || !isMountedRef.current) return;
+        setErrorsByKey((prev) => ({
+          ...prev,
+          [requestKey]: error,
+        }));
+      } finally {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setLoadingByKey((prev) => {
+          if (!prev[requestKey]) return prev;
+          const next = { ...prev };
+          delete next[requestKey];
+          return next;
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, cacheKey, categoryKey, currentResult, isOpen, normalizedRole, trimmedSearch]);
 
   const handleKeyDown = (event, index) => {
     if (CATEGORY_OPTIONS.length === 0) return;
@@ -38,6 +173,12 @@ export default function Marketplace({ isOpen, onSkipToEditor }) {
     }
   };
 
+  const resolvedErrorMessage = currentError
+    ? typeof api?.handleError === 'function'
+      ? api.handleError(currentError)
+      : currentError.message || 'Unable to load marketplace.'
+    : '';
+
   return (
     <div id="marketplacePage" className={`page${isOpen ? '' : ' hidden'}`}>
       <h2>Marketplace</h2>
@@ -52,7 +193,13 @@ export default function Marketplace({ isOpen, onSkipToEditor }) {
       </a>
       <div className="marketplace-layout">
         <aside className="category-sidebar">
-          <input type="text" id="designSearch" placeholder="Search designs" />
+          <input
+            type="text"
+            id="designSearch"
+            placeholder="Search designs"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+          />
           <ul
             id="categoryTabs"
             className="category-tabs"
@@ -81,7 +228,53 @@ export default function Marketplace({ isOpen, onSkipToEditor }) {
             })}
           </ul>
         </aside>
-        <div id="designGrid" className="marketplace-grid"></div>
+        <div id="designGrid" className="marketplace-grid">
+          <div className="marketplace-role-summary" aria-live="polite">
+            Viewing as <strong>{displayRole}</strong>
+          </div>
+          {isLoading && (
+            <div className="marketplace-status" role="status">
+              Loading marketplace…
+            </div>
+          )}
+          {currentError && (
+            <div className="marketplace-error" role="alert">
+              {resolvedErrorMessage}
+            </div>
+          )}
+          {!isLoading && !currentError && listings.length === 0 && (
+            <p className="marketplace-empty">No designs found for this selection.</p>
+          )}
+          {listings.map((listing, index) => {
+            const cardId = listing?.id ? String(listing.id) : `item-${index}`;
+            const designerName = toDesignerName(listing);
+            const flagEntries = extractFlagEntries(listing?.flags);
+            const conversionRateLabel = formatConversionRate(listing?.conversionRate);
+
+            return (
+              <article
+                key={cardId}
+                className="marketplace-card"
+                data-testid={`marketplace-card-${cardId}`}
+              >
+                <h3>{listing?.title || `Design ${cardId}`}</h3>
+                {designerName ? (
+                  <p className="marketplace-designer">{designerName}</p>
+                ) : null}
+                {flagEntries.length > 0 && (
+                  <ul className="marketplace-flags">
+                    {flagEntries.map(([flagKey, flagValue]) => (
+                      <li key={flagKey}>{`${flagKey}: ${String(flagValue)}`}</li>
+                    ))}
+                  </ul>
+                )}
+                {conversionRateLabel !== null && (
+                  <p className="marketplace-conversion">{`Conversion Rate: ${conversionRateLabel}`}</p>
+                )}
+              </article>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/__tests__/Marketplace.test.jsx
+++ b/frontend/components/__tests__/Marketplace.test.jsx
@@ -1,9 +1,48 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Marketplace from '../Marketplace.jsx';
+import useAuth from '../../hooks/useAuth.js';
+
+jest.mock('../../hooks/useAuth.js', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+function mockAuth({ role = 'consumer', listings = [], implementation } = {}) {
+  const normalizedListings = listings.map((listing, index) => ({
+    id: listing.id ?? String(index + 1),
+    title: listing.title ?? `Design ${index + 1}`,
+    designer: listing.designer ?? { displayName: `Designer ${index + 1}` },
+    badges: listing.badges ?? [],
+    ...listing,
+  }));
+
+  const listMarketplace =
+    implementation ??
+    jest.fn().mockResolvedValue({
+      role,
+      data: normalizedListings,
+    });
+
+  useAuth.mockReturnValue({
+    user: { role },
+    api: { listMarketplace },
+    isAuthenticated: true,
+    loading: false,
+    error: null,
+  });
+
+  return { listMarketplace };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('Marketplace', () => {
-  it('toggles the hidden class on the root element when isOpen changes', () => {
+  it('toggles the hidden class on the root element when isOpen changes', async () => {
+    const { listMarketplace } = mockAuth({ listings: [] });
+
     const { container, rerender } = render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
 
     const openRoot = container.querySelector('#marketplacePage');
@@ -17,10 +56,14 @@ describe('Marketplace', () => {
     rerender(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
     const reopenedRoot = container.querySelector('#marketplacePage');
     expect(reopenedRoot).not.toHaveClass('hidden');
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalled());
   });
 
   it('moves focus and updates aria-selected when navigating categories with the keyboard', async () => {
+    const { listMarketplace } = mockAuth({ listings: [] });
     const user = userEvent.setup();
+
     render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
 
     const tabs = screen.getAllByRole('tab');
@@ -49,9 +92,12 @@ describe('Marketplace', () => {
     expect(tabs[0]).toHaveFocus();
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
     expect(tabs[lastIndex]).toHaveAttribute('aria-selected', 'false');
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalled());
   });
 
   it('prevents navigation and triggers onSkipToEditor when the skip link is clicked', async () => {
+    const { listMarketplace } = mockAuth({ listings: [] });
     const user = userEvent.setup();
     const onSkipToEditor = jest.fn();
 
@@ -68,5 +114,123 @@ describe('Marketplace', () => {
     expect(onSkipToEditor).toHaveBeenCalledTimes(1);
     expect(capturedEvents).toHaveLength(1);
     expect(capturedEvents[0].defaultPrevented).toBe(true);
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalled());
+  });
+
+  it('requests new listings when the search input changes', async () => {
+    const listMarketplace = jest.fn().mockResolvedValue({ role: 'consumer', data: [] });
+    mockAuth({ role: 'consumer', implementation: listMarketplace });
+    const user = userEvent.setup();
+
+    render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalledTimes(1));
+
+    const searchInput = screen.getByPlaceholderText(/search designs/i);
+    await user.type(searchInput, 'w');
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalledTimes(2));
+    expect(listMarketplace.mock.calls[1][0]).toEqual({
+      role: 'consumer',
+      category: undefined,
+      search: 'w',
+    });
+  });
+
+  it('requests category-specific listings when a new category is selected', async () => {
+    const listMarketplace = jest.fn().mockResolvedValue({ role: 'consumer', data: [] });
+    mockAuth({ role: 'consumer', implementation: listMarketplace });
+    const user = userEvent.setup();
+
+    render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalledTimes(1));
+
+    const weddingTab = screen.getByRole('tab', { name: /wedding/i });
+    await user.click(weddingTab);
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalledTimes(2));
+    expect(listMarketplace.mock.calls[1][0]).toEqual({
+      role: 'consumer',
+      category: 'wedding',
+      search: undefined,
+    });
+  });
+
+  it('renders consumer listings for consumer role responses', async () => {
+    const consumerListings = [
+      {
+        id: '1',
+        title: 'Sample Birthday Invite',
+        designer: { displayName: 'Studio Omega' },
+      },
+    ];
+    const { listMarketplace } = mockAuth({ role: 'consumer', listings: consumerListings });
+
+    render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
+
+    const card = await screen.findByTestId('marketplace-card-1');
+    expect(card).toHaveTextContent('Sample Birthday Invite');
+    expect(card).toHaveTextContent('Studio Omega');
+
+    expect(listMarketplace).toHaveBeenCalledTimes(1);
+    expect(listMarketplace.mock.calls[0][0]).toEqual({
+      role: 'consumer',
+      category: undefined,
+      search: undefined,
+    });
+  });
+
+  it('renders creator listings with flags for creator role responses', async () => {
+    const creatorListings = [
+      {
+        id: '2',
+        title: 'Wedding Announcement',
+        designer: { displayName: 'Demo Creator' },
+        flags: { isAdminTemplate: true, managedByAdminId: '1' },
+      },
+    ];
+    const { listMarketplace } = mockAuth({ role: 'creator', listings: creatorListings });
+
+    render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
+
+    const card = await screen.findByTestId('marketplace-card-2');
+    expect(card).toHaveTextContent('Wedding Announcement');
+    expect(card).toHaveTextContent('Demo Creator');
+    expect(card).toHaveTextContent('isAdminTemplate: true');
+
+    expect(listMarketplace).toHaveBeenCalledTimes(1);
+    expect(listMarketplace.mock.calls[0][0]).toEqual({
+      role: 'creator',
+      category: undefined,
+      search: undefined,
+    });
+  });
+
+  it('renders admin marketplace metrics for admin role responses', async () => {
+    const adminListings = [
+      {
+        id: '1',
+        title: 'Premium Event Template',
+        designer: { displayName: 'Studio Omega' },
+        conversionRate: 0.5,
+      },
+    ];
+    const { listMarketplace } = mockAuth({ role: 'admin', listings: adminListings });
+
+    render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
+
+    const card = await screen.findByTestId('marketplace-card-1');
+    expect(card).toHaveTextContent('Premium Event Template');
+    expect(card).toHaveTextContent('Studio Omega');
+    expect(card).toHaveTextContent('Conversion Rate: 50%');
+
+    expect(listMarketplace).toHaveBeenCalledTimes(1);
+    expect(listMarketplace.mock.calls[0][0]).toEqual({
+      role: 'admin',
+      category: undefined,
+      search: undefined,
+    });
   });
 });

--- a/frontend/services/api-client.js
+++ b/frontend/services/api-client.js
@@ -380,6 +380,26 @@ class APIClient {
     return this.post('/purchase', { tokens: amount });
   }
 
+  // Marketplace endpoints
+  async listMarketplace(filters = {}) {
+    const params = {};
+    const { role, category, search } = filters || {};
+
+    if (typeof role === 'string' && role.trim()) {
+      params.role = role.trim().toLowerCase();
+    }
+
+    if (typeof category === 'string' && category.trim()) {
+      params.category = category.trim();
+    }
+
+    if (typeof search === 'string' && search.trim()) {
+      params.search = search.trim();
+    }
+
+    return this.get('/api/marketplace', params);
+  }
+
   // Enhanced authentication methods with session management
   async register(userData) {
     this.isRetrying = true;


### PR DESCRIPTION
## Summary
- add an API client helper to retrieve marketplace listings with optional filters
- update the Marketplace component to fetch role-aware data, cache results per filter, and render listings with status messaging
- expand Marketplace tests to exercise search/category fetches and consumer, creator, and admin result handling

## Testing
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68cd63623e80832aa81f4c04ee6e41f6