### PR TITLE
Add navigation state API with integration tests

### DIFF
--- a/server/__tests__/navigation-state-api.test.js
+++ b/server/__tests__/navigation-state-api.test.js
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+
+import { acquireTestServer } from './test-server.js';
+
+process.env.JWT_SECRET ??= 'test-secret';
+process.env.NODE_ENV = 'test';
+
+const { default: server } = await import('../index.js');
+
+let baseUrl;
+let serverHandle;
+
+function signJwt(payload) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const data = `${headerB64}.${payloadB64}`;
+  const signature = createHmac('sha256', process.env.JWT_SECRET).update(data).digest('base64url');
+  return `${data}.${signature}`;
+}
+
+function buildAuthHeaders(userId, role = 'user') {
+  const exp = Math.floor(Date.now() / 1000) + 60 * 60;
+  const token = signJwt({ sub: userId, role, exp });
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  let body;
+  if (response.status !== 204) {
+    try {
+      body = await response.json();
+    } catch (err) {
+      body = null;
+    }
+  }
+  return { response, body };
+}
+
+test.before(async () => {
+  serverHandle = await acquireTestServer(server);
+  baseUrl = serverHandle.baseUrl;
+});
+
+test.after(async () => {
+  if (serverHandle) {
+    await serverHandle.release();
+    serverHandle = null;
+  }
+});
+
+test('GET /api/navigation/state returns an empty object by default', async () => {
+  const { response, body } = await request('/api/navigation/state', {
+    method: 'GET',
+    headers: buildAuthHeaders('nav-default-user')
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, { state: {} });
+});
+
+test('PUT /api/navigation/state saves the provided state for the user', async () => {
+  const userId = 'nav-save-user';
+  const payload = {
+    currentStep: 'details',
+    completedSteps: ['intro']
+  };
+
+  const { response: saveResponse, body: saveBody } = await request('/api/navigation/state', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...buildAuthHeaders(userId)
+    },
+    body: JSON.stringify(payload)
+  });
+
+  assert.equal(saveResponse.status, 200);
+  assert.deepEqual(saveBody, { state: payload });
+
+  const { response: fetchResponse, body: fetchBody } = await request('/api/navigation/state', {
+    method: 'GET',
+    headers: buildAuthHeaders(userId)
+  });
+
+  assert.equal(fetchResponse.status, 200);
+  assert.deepEqual(fetchBody, { state: payload });
+});
+
+test('PATCH /api/navigation/state merges updates into the existing state', async () => {
+  const userId = 'nav-partial-user';
+  const initialState = { currentStep: 'templates', layout: 'grid' };
+
+  await request('/api/navigation/state', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...buildAuthHeaders(userId)
+    },
+    body: JSON.stringify(initialState)
+  });
+
+  const updates = { layout: 'list', lastVisitedAt: '2024-01-01T00:00:00.000Z' };
+  const { response: patchResponse, body: patchBody } = await request('/api/navigation/state', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...buildAuthHeaders(userId)
+    },
+    body: JSON.stringify(updates)
+  });
+
+  assert.equal(patchResponse.status, 200);
+  assert.deepEqual(patchBody, {
+    state: {
+      currentStep: 'templates',
+      layout: 'list',
+      lastVisitedAt: '2024-01-01T00:00:00.000Z'
+    }
+  });
+});
+
+test('PUT /api/navigation/state requires authentication', async () => {
+  const { response, body } = await request('/api/navigation/state', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ currentStep: 'details' })
+  });
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(body, {
+    error: {
+      type: 'authorization_error',
+      message: 'Authentication required'
+    }
+  });
+});

--- a/server/__tests__/test-server.js
+++ b/server/__tests__/test-server.js
@@ -1,0 +1,60 @@
+const state = {
+  refCount: 0,
+  starting: null
+};
+
+export async function acquireTestServer(server) {
+  state.refCount += 1;
+  try {
+    if (server.listening) {
+      if (state.starting) {
+        await state.starting;
+      }
+    } else {
+      if (!state.starting) {
+        const startPromise = new Promise((resolve, reject) => {
+          const onError = (err) => {
+            server.off('error', onError);
+            reject(err);
+          };
+          server.once('error', onError);
+          server.listen(0, () => {
+            server.off('error', onError);
+            resolve();
+          });
+        });
+        state.starting = startPromise.finally(() => {
+          state.starting = null;
+        });
+      }
+      await state.starting;
+    }
+
+    const address = server.address();
+    const baseUrl =
+      typeof address === 'string' ? address : `http://127.0.0.1:${address?.port ?? 0}`;
+
+    return {
+      baseUrl,
+      async release() {
+        if (state.refCount === 0) {
+          return;
+        }
+        state.refCount -= 1;
+        if (state.refCount === 0) {
+          if (state.starting) {
+            await state.starting;
+          }
+          if (server.listening) {
+            await new Promise((resolve, reject) => {
+              server.close((err) => (err ? reject(err) : resolve()));
+            });
+          }
+        }
+      }
+    };
+  } catch (err) {
+    state.refCount = Math.max(0, state.refCount - 1);
+    throw err;
+  }
+}

--- a/server/navigation-state-store.js
+++ b/server/navigation-state-store.js
@@ -1,0 +1,44 @@
+const navigationStateByUser = new Map();
+
+function normalizeUserId(userId) {
+  const id = String(userId ?? '').trim();
+  if (!id) {
+    throw new Error('userId is required to access navigation state');
+  }
+  return id;
+}
+
+function assertPlainObject(value, message) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(message);
+  }
+}
+
+function cloneState(state) {
+  return Object.assign({}, state);
+}
+
+export function getNavigationState(userId) {
+  const id = normalizeUserId(userId);
+  const existing = navigationStateByUser.get(id);
+  return existing ? cloneState(existing) : {};
+}
+
+export function saveNavigationState(userId, updates) {
+  const id = normalizeUserId(userId);
+  assertPlainObject(updates, 'Navigation state must be provided as an object');
+
+  const current = navigationStateByUser.get(id) || {};
+  const merged = cloneState(current);
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      delete merged[key];
+    } else {
+      merged[key] = value;
+    }
+  }
+
+  navigationStateByUser.set(id, merged);
+  return cloneState(merged);
+}


### PR DESCRIPTION
## Summary
- add an in-memory navigation state store with helpers for retrieving and saving state per user
- expose GET, PUT, and PATCH /api/navigation/state endpoints that use the new store with validation and auth
- share reusable test server helper and cover navigation state flows with integration tests

## Testing
- node --test server/__tests__/*.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd6eaaee58832a9830e2fdd8f2e015