### PR TITLE
Fix design ownership reset loop and verify tests

### DIFF
--- a/frontend/components/PreviewModal.jsx
+++ b/frontend/components/PreviewModal.jsx
@@ -1,9 +1,51 @@
+import { useEffect, useMemo } from 'react';
+import useDesignOwnership from '../hooks/useDesignOwnership.js';
 import useModalFocusTrap from '../hooks/useModalFocusTrap.js';
 
-export default function PreviewModal({ isOpen, onClose, onUseDesign }) {
+export default function PreviewModal({ isOpen, designId, onClose, onUseDesign }) {
   const modalRef = useModalFocusTrap(isOpen, onClose);
+  const {
+    currentDesignId,
+    setCurrentDesignId,
+    ensureOwnership,
+    isDesignOwned,
+    loading,
+    error,
+  } = useDesignOwnership();
+
+  const resolvedDesignId = useMemo(() => {
+    const rawId = designId !== undefined ? designId : currentDesignId;
+    if (rawId === null || rawId === undefined) {
+      return null;
+    }
+    return typeof rawId === 'string' ? rawId : String(rawId);
+  }, [currentDesignId, designId]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (resolvedDesignId) {
+      setCurrentDesignId(resolvedDesignId);
+      ensureOwnership(resolvedDesignId).catch(() => {});
+    }
+  }, [ensureOwnership, isOpen, resolvedDesignId, setCurrentDesignId]);
 
   if (!isOpen) return null;
+
+  const owned = resolvedDesignId ? isDesignOwned(resolvedDesignId) : false;
+  const buttonLabel = owned ? 'Edit This Design' : 'Use This Design';
+  const statusMessage = (() => {
+    if (loading) return 'Checking ownership status…';
+    if (owned) return 'You already own this design.';
+    if (error) return 'Unable to verify ownership. You may need to purchase this design.';
+    return 'Preview this design before deciding to use it.';
+  })();
+
+  const handleUseDesign = () => {
+    onUseDesign?.({ designId: resolvedDesignId, owned });
+  };
 
   return (
     <div
@@ -16,8 +58,16 @@ export default function PreviewModal({ isOpen, onClose, onUseDesign }) {
       <div className="preview-content">
         <button id="previewClose" className="iconbtn preview-close" aria-label="Close preview" onClick={onClose}>×</button>
         <div id="previewSlides" className="preview-slides"></div>
+        <p id="previewStatus" className="preview-status" aria-live="polite">{statusMessage}</p>
         <div className="preview-actions">
-          <button id="useDesignBtn" className="btn primary" onClick={onUseDesign}>Use This Design</button>
+          <button
+            id="useDesignBtn"
+            className="btn primary"
+            onClick={handleUseDesign}
+            disabled={!resolvedDesignId}
+          >
+            {buttonLabel}
+          </button>
           <button id="favoriteDesignBtn" className="btn">Favorite</button>
         </div>
       </div>

--- a/frontend/components/PurchaseModal.jsx
+++ b/frontend/components/PurchaseModal.jsx
@@ -1,9 +1,68 @@
+import { useEffect, useMemo, useState } from 'react';
+import useDesignOwnership from '../hooks/useDesignOwnership.js';
 import useModalFocusTrap from '../hooks/useModalFocusTrap.js';
 
-export default function PurchaseModal({ isOpen, onConfirm, onCancel }) {
+export default function PurchaseModal({ isOpen, designId, onConfirm, onCancel }) {
   const modalRef = useModalFocusTrap(isOpen, onCancel);
+  const {
+    currentDesignId,
+    setCurrentDesignId,
+    isDesignOwned,
+    markDesignOwned,
+    loading,
+    error,
+  } = useDesignOwnership();
+  const [confirming, setConfirming] = useState(false);
+
+  const resolvedDesignId = useMemo(() => {
+    const rawId = designId !== undefined ? designId : currentDesignId;
+    if (rawId === null || rawId === undefined) {
+      return null;
+    }
+    return typeof rawId === 'string' ? rawId : String(rawId);
+  }, [currentDesignId, designId]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setConfirming(false);
+      return;
+    }
+    if (resolvedDesignId) {
+      setCurrentDesignId(resolvedDesignId);
+    }
+  }, [isOpen, resolvedDesignId, setCurrentDesignId]);
 
   if (!isOpen) return null;
+
+  const owned = resolvedDesignId ? isDesignOwned(resolvedDesignId) : false;
+  const baseMessage = owned
+    ? 'You already own this design. Start editing when you are ready.'
+    : 'You need tokens to edit this design.';
+  const statusMessage = error && !owned
+    ? 'We were unable to verify your ownership status. Please try again later.'
+    : baseMessage;
+  const confirmLabel = owned ? 'Start Editing' : 'Confirm Purchase';
+
+  const handleConfirm = async () => {
+    if (confirming) return;
+    setConfirming(true);
+
+    try {
+      let nextOwned = owned;
+      if (!nextOwned && resolvedDesignId) {
+        markDesignOwned(resolvedDesignId, { owned: true, purchasedAt: new Date().toISOString() });
+        nextOwned = true;
+      }
+      onConfirm?.({ designId: resolvedDesignId, owned: nextOwned });
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (confirming) return;
+    onCancel?.();
+  };
 
   return (
     <div
@@ -14,10 +73,17 @@ export default function PurchaseModal({ isOpen, onConfirm, onCancel }) {
       ref={modalRef}
     >
       <div className="purchase-content">
-        <p id="purchaseMessage">You need tokens to edit this design.</p>
+        <p id="purchaseMessage" aria-live="polite">{statusMessage}</p>
         <div className="purchase-actions">
-          <button id="purchaseConfirm" className="btn primary" onClick={onConfirm}>Confirm</button>
-          <button id="purchaseCancel" className="btn" onClick={onCancel}>Cancel</button>
+          <button
+            id="purchaseConfirm"
+            className="btn primary"
+            onClick={handleConfirm}
+            disabled={loading || confirming || !resolvedDesignId}
+          >
+            {confirmLabel}
+          </button>
+          <button id="purchaseCancel" className="btn" onClick={handleCancel} disabled={confirming}>Cancel</button>
         </div>
       </div>
     </div>

--- a/frontend/components/__tests__/PreviewModal.test.jsx
+++ b/frontend/components/__tests__/PreviewModal.test.jsx
@@ -2,16 +2,34 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PreviewModal from '../PreviewModal.jsx';
 import useModalFocusTrap from '../../hooks/useModalFocusTrap.js';
+import useDesignOwnership from '../../hooks/useDesignOwnership.js';
 
 jest.mock('../../hooks/useModalFocusTrap.js', () => ({
   __esModule: true,
   default: jest.fn(() => ({ current: null })),
 }));
 
+jest.mock('../../hooks/useDesignOwnership.js', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const createDesignOwnershipValue = (overrides = {}) => ({
+  currentDesignId: 'preview-design',
+  setCurrentDesignId: jest.fn(),
+  ensureOwnership: jest.fn().mockResolvedValue(true),
+  isDesignOwned: jest.fn().mockReturnValue(false),
+  loading: false,
+  error: null,
+  ...overrides,
+});
+
 describe('PreviewModal', () => {
   beforeEach(() => {
     useModalFocusTrap.mockClear();
     useModalFocusTrap.mockImplementation(() => ({ current: null }));
+    useDesignOwnership.mockReset();
+    useDesignOwnership.mockReturnValue(createDesignOwnershipValue());
   });
 
   it('does not render when the modal is closed', () => {
@@ -40,6 +58,7 @@ describe('PreviewModal', () => {
     expect(dialog).toHaveAttribute('aria-modal', 'true');
     expect(screen.getByRole('button', { name: /use this design/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /favorite/i })).toBeInTheDocument();
+    expect(screen.getByText(/preview this design/i)).toBeInTheDocument();
   });
 
   it('invokes the provided callbacks when buttons are clicked', async () => {
@@ -53,6 +72,20 @@ describe('PreviewModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByRole('button', { name: /use this design/i }));
-    expect(onUseDesign).toHaveBeenCalledTimes(1);
+    expect(onUseDesign).toHaveBeenCalledWith({ designId: 'preview-design', owned: false });
+  });
+
+  it('updates the button label when the design is owned', () => {
+    const ownershipValue = createDesignOwnershipValue({
+      isDesignOwned: jest.fn().mockReturnValue(true),
+      loading: false,
+      currentDesignId: 'owned-design',
+    });
+    useDesignOwnership.mockReturnValue(ownershipValue);
+
+    render(<PreviewModal isOpen designId="owned-design" onClose={() => {}} onUseDesign={() => {}} />);
+
+    expect(screen.getByRole('button', { name: /edit this design/i })).toBeInTheDocument();
+    expect(screen.getByText(/you already own this design/i)).toBeInTheDocument();
   });
 });

--- a/frontend/components/__tests__/PurchaseModal.test.jsx
+++ b/frontend/components/__tests__/PurchaseModal.test.jsx
@@ -2,16 +2,37 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PurchaseModal from '../PurchaseModal.jsx';
 import useModalFocusTrap from '../../hooks/useModalFocusTrap.js';
+import useDesignOwnership from '../../hooks/useDesignOwnership.js';
 
 jest.mock('../../hooks/useModalFocusTrap.js', () => ({
   __esModule: true,
   default: jest.fn(() => ({ current: null })),
 }));
 
+jest.mock('../../hooks/useDesignOwnership.js', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const createOwnershipValue = (overrides = {}) => ({
+  currentDesignId: 'purchase-design',
+  setCurrentDesignId: jest.fn(),
+  isDesignOwned: jest.fn().mockReturnValue(false),
+  markDesignOwned: jest.fn(),
+  loading: false,
+  error: null,
+  ...overrides,
+});
+
 describe('PurchaseModal', () => {
+  let designOwnership;
+
   beforeEach(() => {
     useModalFocusTrap.mockClear();
     useModalFocusTrap.mockImplementation(() => ({ current: null }));
+    useDesignOwnership.mockReset();
+    designOwnership = createOwnershipValue();
+    useDesignOwnership.mockReturnValue(designOwnership);
   });
 
   it('does not render when the modal is closed', () => {
@@ -39,7 +60,7 @@ describe('PurchaseModal', () => {
     expect(dialog).toBeInTheDocument();
     expect(dialog).toHaveAttribute('aria-modal', 'true');
     expect(screen.getByText('You need tokens to edit this design.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /confirm purchase/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
   });
 
@@ -50,10 +71,24 @@ describe('PurchaseModal', () => {
 
     render(<PurchaseModal isOpen onConfirm={onConfirm} onCancel={onCancel} />);
 
-    await user.click(screen.getByRole('button', { name: /confirm/i }));
-    expect(onConfirm).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: /confirm purchase/i }));
+    expect(onConfirm).toHaveBeenCalledWith({ designId: 'purchase-design', owned: true });
+    expect(designOwnership.markDesignOwned).toHaveBeenCalledWith('purchase-design', expect.objectContaining({ owned: true }));
 
     await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an alternate message when the design is already owned', () => {
+    const ownership = createOwnershipValue({
+      isDesignOwned: jest.fn().mockReturnValue(true),
+      currentDesignId: 'owned',
+    });
+    useDesignOwnership.mockReturnValue(ownership);
+
+    render(<PurchaseModal isOpen designId="owned" onConfirm={() => {}} onCancel={() => {}} />);
+
+    expect(screen.getByText(/you already own this design/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start editing/i })).toBeInTheDocument();
   });
 });

--- a/frontend/hooks/__tests__/useDesignOwnership.test.jsx
+++ b/frontend/hooks/__tests__/useDesignOwnership.test.jsx
@@ -1,0 +1,96 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { AppStateProvider } from '../../context/AppStateContext.jsx';
+import useDesignOwnership from '../useDesignOwnership.js';
+import useAuth from '../useAuth.js';
+
+jest.mock('../useAuth.js', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const wrapper = ({ children }) => (
+  <AppStateProvider>{children}</AppStateProvider>
+);
+
+describe('useDesignOwnership', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads owned designs for authenticated users and reports ownership', async () => {
+    const getUserDesigns = jest.fn().mockResolvedValue({ designs: [{ id: 'design-1' }, { id: 'design-2', owned: false }] });
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      api: { getUserDesigns },
+    });
+
+    const { result } = renderHook(() => useDesignOwnership(), { wrapper });
+
+    await act(async () => {
+      await result.current.refreshOwnership();
+    });
+
+    expect(result.current.isDesignOwned('design-1')).toBe(true);
+    expect(result.current.isDesignOwned('design-2')).toBe(false);
+  });
+
+  it('exposes manual refresh helpers and surfaces errors', async () => {
+    const error = new Error('network');
+    const getUserDesigns = jest.fn().mockRejectedValue(error);
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      api: { getUserDesigns },
+    });
+
+    const { result } = renderHook(() => useDesignOwnership(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(getUserDesigns).toHaveBeenCalled();
+    });
+    expect(result.current.error?.message).toBe('network');
+    expect(result.current.isDesignOwned('unknown')).toBe(false);
+
+    await act(async () => {
+      await expect(result.current.refreshOwnership()).rejects.toThrow('network');
+    });
+
+    const recoveryResponse = { designs: [{ id: 'restored', owned: true }] };
+    getUserDesigns.mockResolvedValueOnce(recoveryResponse);
+
+    await act(async () => {
+      await result.current.refreshOwnership();
+    });
+
+    expect(result.current.isDesignOwned('restored')).toBe(true);
+  });
+
+  it('allows manually marking and clearing ownership entries', async () => {
+    const getUserDesigns = jest.fn().mockResolvedValue({ designs: [] });
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      api: { getUserDesigns },
+    });
+
+    const { result } = renderHook(() => useDesignOwnership(), { wrapper });
+
+    await waitFor(() => {
+      expect(getUserDesigns).toHaveBeenCalledTimes(1);
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isDesignOwned('manual')).toBe(false);
+
+    act(() => {
+      result.current.markDesignOwned('manual');
+    });
+
+    expect(result.current.isDesignOwned('manual')).toBe(true);
+
+    act(() => {
+      result.current.clearDesignOwnership('manual');
+    });
+
+    expect(result.current.isDesignOwned('manual')).toBe(false);
+  });
+});

--- a/frontend/hooks/useAuth.js
+++ b/frontend/hooks/useAuth.js
@@ -8,7 +8,12 @@ export default function useAuth() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const { setUserRole, resetUserRole } = useAppState();
+  const {
+    setUserRole,
+    resetUserRole,
+    resetDesignOwnership,
+    setCurrentDesignId,
+  } = useAppState();
 
   const applyUserRole = useCallback(
     (nextUser) => {
@@ -40,8 +45,10 @@ export default function useAuth() {
 
     if (!appliedRole) {
       resetUserRole();
+      resetDesignOwnership();
+      setCurrentDesignId(null);
     }
-  }, [api, applyUserRole, resetUserRole]);
+  }, [api, applyUserRole, resetDesignOwnership, resetUserRole, setCurrentDesignId]);
 
   const login = useCallback(
     async ({ email, password, remember = false }) => {
@@ -54,6 +61,8 @@ export default function useAuth() {
           applyUserRole(res.user);
         } else {
           resetUserRole();
+          resetDesignOwnership();
+          setCurrentDesignId(null);
         }
         return res;
       } catch (e) {
@@ -63,7 +72,7 @@ export default function useAuth() {
         setLoading(false);
       }
     },
-    [api, applyUserRole, resetUserRole]
+    [api, applyUserRole, resetDesignOwnership, resetUserRole, setCurrentDesignId]
   );
 
   const logout = useCallback(async () => {
@@ -73,15 +82,19 @@ export default function useAuth() {
       await api.logout();
       setUser(null);
       resetUserRole();
+      resetDesignOwnership();
+      setCurrentDesignId(null);
     } catch (e) {
       // surface warning but still clear local state
       setError(e);
       setUser(null);
       resetUserRole();
+      resetDesignOwnership();
+      setCurrentDesignId(null);
     } finally {
       setLoading(false);
     }
-  }, [api, resetUserRole]);
+  }, [api, resetDesignOwnership, resetUserRole, setCurrentDesignId]);
 
   const refreshUser = useCallback(async () => {
     setLoading(true);
@@ -93,16 +106,20 @@ export default function useAuth() {
         applyUserRole(res.user);
       } else {
         resetUserRole();
+        resetDesignOwnership();
+        setCurrentDesignId(null);
       }
       return res?.user ?? null;
     } catch (e) {
       setError(e);
       resetUserRole();
+      resetDesignOwnership();
+      setCurrentDesignId(null);
       return null;
     } finally {
       setLoading(false);
     }
-  }, [api, applyUserRole, resetUserRole]);
+  }, [api, applyUserRole, resetDesignOwnership, resetUserRole, setCurrentDesignId]);
 
   return {
     // state

--- a/frontend/hooks/useDesignOwnership.js
+++ b/frontend/hooks/useDesignOwnership.js
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useAppState } from '../context/AppStateContext.jsx';
+import useAuth from './useAuth.js';
+
+function normalizeDesignList(response) {
+  if (!response) return [];
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response.designs)) return response.designs;
+  if (Array.isArray(response.items)) return response.items;
+  if (Array.isArray(response.data)) return response.data;
+  if (Array.isArray(response.results)) return response.results;
+  return [];
+}
+
+function normalizeOwnershipEntry(entry) {
+  if (entry === null || entry === undefined) {
+    return null;
+  }
+
+  if (typeof entry === 'string' || typeof entry === 'number') {
+    const id = typeof entry === 'string' ? entry : String(entry);
+    return { id, owned: true };
+  }
+
+  if (typeof entry !== 'object') {
+    return null;
+  }
+
+  const rawId = entry.id ?? entry.designId ?? entry.token ?? entry.slug ?? entry.uuid ?? null;
+  if (rawId === null || rawId === undefined) {
+    return null;
+  }
+
+  const id = typeof rawId === 'string' ? rawId : String(rawId);
+  const owned = entry.owned !== undefined ? Boolean(entry.owned) : true;
+
+  return {
+    ...entry,
+    id,
+    owned,
+  };
+}
+
+export default function useDesignOwnership() {
+  const {
+    designOwnership = {},
+    setCurrentDesignId,
+    setDesignOwnershipLoading,
+    setDesignOwnershipError,
+    setDesignOwnershipEntries,
+    clearDesignOwnershipEntry,
+    resetDesignOwnership: resetDesignOwnershipState,
+  } = useAppState();
+
+  const auth = useAuth();
+  const api = auth?.api;
+
+  const currentDesignId = designOwnership.currentDesignId ?? null;
+  const ownershipByDesignId = designOwnership.ownershipByDesignId ?? {};
+  const loading = Boolean(designOwnership.loading);
+  const error = designOwnership.error ?? null;
+
+  const isDesignOwned = useCallback(
+    (designId) => {
+      const resolvedId = designId ?? currentDesignId;
+      if (resolvedId === null || resolvedId === undefined) {
+        return false;
+      }
+      const id = typeof resolvedId === 'string' ? resolvedId : String(resolvedId);
+      const entry = ownershipByDesignId[id];
+      if (!entry) {
+        return false;
+      }
+      if (typeof entry === 'boolean') {
+        return entry;
+      }
+      if (typeof entry.owned === 'boolean') {
+        return entry.owned;
+      }
+      return true;
+    },
+    [currentDesignId, ownershipByDesignId]
+  );
+
+  const getOwnershipEntry = useCallback(
+    (designId) => {
+      const resolvedId = designId ?? currentDesignId;
+      if (resolvedId === null || resolvedId === undefined) {
+        return null;
+      }
+      const id = typeof resolvedId === 'string' ? resolvedId : String(resolvedId);
+      return ownershipByDesignId[id] ?? null;
+    },
+    [currentDesignId, ownershipByDesignId]
+  );
+
+  const attemptedInitialLoadRef = useRef(false);
+
+  const refreshOwnership = useCallback(async () => {
+    attemptedInitialLoadRef.current = true;
+    if (!api || typeof api.getUserDesigns !== 'function') {
+      setDesignOwnershipEntries([], { replace: true });
+      return [];
+    }
+    setDesignOwnershipLoading(true);
+    setDesignOwnershipError(null);
+
+    try {
+      const response = await api.getUserDesigns();
+      const designs = normalizeDesignList(response);
+      const entries = designs.map(normalizeOwnershipEntry).filter(Boolean);
+      setDesignOwnershipEntries(entries, { replace: true });
+      return entries;
+    } catch (err) {
+      setDesignOwnershipError(err);
+      setDesignOwnershipEntries([], { replace: true });
+      throw err;
+    } finally {
+      setDesignOwnershipLoading(false);
+    }
+  }, [api, setDesignOwnershipEntries, setDesignOwnershipError, setDesignOwnershipLoading]);
+
+  const ensureOwnership = useCallback(
+    async (designId) => {
+      const targetId = designId ?? currentDesignId;
+      if (targetId === null || targetId === undefined) {
+        return false;
+      }
+      if (isDesignOwned(targetId)) {
+        return true;
+      }
+      try {
+        const entries = await refreshOwnership();
+        return entries.some((entry) => entry.id === (typeof targetId === 'string' ? targetId : String(targetId)) && entry.owned);
+      } catch (_) {
+        return false;
+      }
+    },
+    [currentDesignId, isDesignOwned, refreshOwnership]
+  );
+
+  const markDesignOwned = useCallback(
+    (designId, details = {}) => {
+      const targetId = designId ?? currentDesignId;
+      if (targetId === null || targetId === undefined) {
+        return null;
+      }
+      const id = typeof targetId === 'string' ? targetId : String(targetId);
+      const entry = normalizeOwnershipEntry({ id, owned: true, ...details });
+      if (!entry) return null;
+      setDesignOwnershipEntries([entry], { replace: false });
+      return entry;
+    },
+    [currentDesignId, setDesignOwnershipEntries]
+  );
+
+  const clearDesignOwnership = useCallback(
+    (designId) => {
+      const targetId = designId ?? currentDesignId;
+      if (targetId === null || targetId === undefined) {
+        return;
+      }
+      const id = typeof targetId === 'string' ? targetId : String(targetId);
+      clearDesignOwnershipEntry(id);
+    },
+    [clearDesignOwnershipEntry, currentDesignId]
+  );
+
+  const wasAuthenticatedRef = useRef(Boolean(auth?.isAuthenticated));
+
+  const resetDesignOwnership = useCallback(() => {
+    attemptedInitialLoadRef.current = false;
+    const hasEntries = Object.keys(ownershipByDesignId).length > 0;
+    const hasActiveDesign = currentDesignId !== null && currentDesignId !== undefined;
+    const hasError = Boolean(error);
+    if (!hasEntries && !hasActiveDesign && !loading && !hasError) {
+      return;
+    }
+    resetDesignOwnershipState();
+  }, [currentDesignId, error, loading, ownershipByDesignId, resetDesignOwnershipState]);
+
+  useEffect(() => {
+    const isAuthenticated = Boolean(auth?.isAuthenticated);
+
+    if (!isAuthenticated) {
+      const hasEntries = Object.keys(ownershipByDesignId).length > 0;
+      const hasError = Boolean(error);
+      const shouldReset =
+        wasAuthenticatedRef.current ||
+        hasEntries ||
+        hasError ||
+        loading;
+      if (shouldReset) {
+        resetDesignOwnership();
+      }
+      wasAuthenticatedRef.current = false;
+      attemptedInitialLoadRef.current = false;
+      return;
+    }
+
+    wasAuthenticatedRef.current = true;
+
+    if (loading) {
+      return;
+    }
+
+    const hasEntries = Object.keys(ownershipByDesignId).length > 0;
+    if (!hasEntries && !attemptedInitialLoadRef.current) {
+      attemptedInitialLoadRef.current = true;
+      refreshOwnership().catch(() => {});
+    }
+  }, [
+    auth?.isAuthenticated,
+    currentDesignId,
+    error,
+    loading,
+    ownershipByDesignId,
+    refreshOwnership,
+    resetDesignOwnership,
+  ]);
+
+  const value = useMemo(
+    () => ({
+      currentDesignId,
+      ownershipByDesignId,
+      loading,
+      error,
+      isDesignOwned,
+      getOwnershipEntry,
+      setCurrentDesignId,
+      refreshOwnership,
+      ensureOwnership,
+      markDesignOwned,
+      clearDesignOwnership,
+      resetDesignOwnership,
+    }),
+    [
+      clearDesignOwnership,
+      currentDesignId,
+      error,
+      getOwnershipEntry,
+      isDesignOwned,
+      loading,
+      markDesignOwned,
+      ownershipByDesignId,
+      refreshOwnership,
+      resetDesignOwnership,
+      setCurrentDesignId,
+      ensureOwnership,
+    ]
+  );
+
+  return value;
+}

--- a/frontend/pages/__tests__/index.test.jsx
+++ b/frontend/pages/__tests__/index.test.jsx
@@ -31,6 +31,7 @@ const createAuthValue = (overrides = {}) => {
     refreshUser: jest.fn(),
     api: {
       isAuthenticated: () => isAuthenticated,
+      getUserDesigns: jest.fn().mockResolvedValue({ designs: [] }),
     },
     ...overrides,
   };
@@ -117,6 +118,9 @@ describe('MarketplacePage', () => {
       expect(screen.queryByRole('button', { name: /use this design/i })).not.toBeInTheDocument();
     });
 
+    const confirmPurchaseButton = await screen.findByRole('button', { name: /confirm purchase/i });
+    expect(confirmPurchaseButton).toBeInTheDocument();
+
     const cancelPurchaseButton = await screen.findByRole('button', { name: /cancel/i });
     expect(cancelPurchaseButton).toBeInTheDocument();
 
@@ -124,6 +128,7 @@ describe('MarketplacePage', () => {
 
     await waitFor(() => {
       expect(screen.queryByText(/you need tokens to edit this design/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /confirm purchase/i })).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- guard the design ownership effect and expose helpers through the new `useDesignOwnership` hook
- wire marketplace/editor surfaces plus preview and purchase modals into the ownership flow
- expand reducer, hook, and page tests for owned vs. unowned scenarios

## Testing
- CI=1 npm --prefix frontend test -- --runInBand --verbose

------
https://chatgpt.com/codex/tasks/task_e_68cd7d8979f4832aba35c33d505991a9