### PR TITLE
Add file upload workflow for background uploads

### DIFF
--- a/frontend/components/ImageCanvas.jsx
+++ b/frontend/components/ImageCanvas.jsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import { useAppState } from '../context/AppStateContext.jsx';
 
 // Minimal image canvas that mirrors image-manager.js transform state
-export default function ImageCanvas() {
+export default function ImageCanvas({ children }) {
   const { imgState, workSize } = useAppState();
 
   const transform = useMemo(() => {
@@ -55,6 +55,7 @@ export default function ImageCanvas() {
           <div style={{ color: '#94a3b8', fontSize: 12, padding: 8 }}>No image selected</div>
         )}
       </div>
+      {children}
     </div>
   );
 }

--- a/frontend/components/UploadBackgroundButton.jsx
+++ b/frontend/components/UploadBackgroundButton.jsx
@@ -1,0 +1,94 @@
+import { useMemo, useRef } from 'react';
+import useFileUpload from '../hooks/useFileUpload.js';
+
+export default function UploadBackgroundButton({ api }) {
+  const inputRef = useRef(null);
+  const {
+    status,
+    progress,
+    error,
+    lastUpload,
+    isUploading,
+    handleInputChange,
+  } = useFileUpload({ api });
+
+  const buttonLabel = isUploading
+    ? `Uploading… ${Math.round(progress)}%`
+    : 'Upload Background';
+  const disabled = isUploading || !api || typeof api.uploadImage !== 'function';
+
+  const progressValue = useMemo(() => Math.round(progress), [progress]);
+  const showProgress = isUploading;
+  const showSuccess = status === 'success' && lastUpload?.fileName;
+  const showError = status === 'error' && error;
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        id="bgFileInput"
+        type="file"
+        accept="image/*"
+        aria-label="Upload background image"
+        onChange={handleInputChange}
+        style={{ display: 'none' }}
+      />
+      <button
+        id="uploadBgBtn"
+        type="button"
+        className="btn"
+        onClick={() => inputRef.current?.click()}
+        disabled={disabled}
+      >
+        {buttonLabel}
+      </button>
+      {(showProgress || showSuccess || showError) && (
+        <div
+          className="upload-feedback"
+          aria-live="polite"
+          style={{ marginTop: 8, fontSize: 12 }}
+        >
+          {showProgress && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              <progress
+                value={progress}
+                max={100}
+                aria-label="Upload progress"
+                style={{ width: 160 }}
+              />
+              <span>{progressValue}%</span>
+            </div>
+          )}
+          {showSuccess && (
+            <p
+              role="status"
+              style={{
+                margin: '4px 0 0',
+                color: 'var(--text-success, #16a34a)',
+              }}
+            >
+              Uploaded {lastUpload.fileName}
+            </p>
+          )}
+          {showError && (
+            <p
+              role="alert"
+              style={{
+                margin: '4px 0 0',
+                color: 'var(--text-danger, #ef4444)',
+              }}
+            >
+              {error.message || String(error)}
+            </p>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/__tests__/ImageCanvas.test.jsx
+++ b/frontend/components/__tests__/ImageCanvas.test.jsx
@@ -17,10 +17,10 @@ jest.mock('../../context/AppStateContext.jsx', () => {
 
 import { MockAppStateProvider } from '../../context/AppStateContext.jsx';
 
-function renderImageCanvas(value) {
+function renderImageCanvas(value, childNodes = null) {
   return render(
     <MockAppStateProvider value={value}>
-      <ImageCanvas />
+      <ImageCanvas>{childNodes}</ImageCanvas>
     </MockAppStateProvider>
   );
 }
@@ -102,5 +102,18 @@ describe('ImageCanvas', () => {
 
     const image = screen.getByAltText('Background');
     expect(image).toHaveAttribute('src', imageUrls.backendImageUrl);
+  });
+
+  it('renders children inside the canvas container', () => {
+    const { container } = renderImageCanvas(
+      {
+        imgState: { ...baseImgState },
+        workSize: { w: 400, h: 300 },
+      },
+      <span data-testid="overlay">Overlay</span>
+    );
+
+    const overlay = container.querySelector('[data-testid="overlay"]');
+    expect(overlay).toBeInTheDocument();
   });
 });

--- a/frontend/components/__tests__/UploadBackgroundButton.test.jsx
+++ b/frontend/components/__tests__/UploadBackgroundButton.test.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import UploadBackgroundButton from '../UploadBackgroundButton.jsx';
+import useFileUpload from '../../hooks/useFileUpload.js';
+
+jest.mock('../../hooks/useFileUpload.js');
+
+describe('UploadBackgroundButton', () => {
+  const setupHook = (overrides = {}) => {
+    const defaultState = {
+      status: 'idle',
+      progress: 0,
+      error: null,
+      lastUpload: null,
+      isUploading: false,
+      handleInputChange: jest.fn(),
+    };
+    useFileUpload.mockReturnValue({ ...defaultState, ...overrides });
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the upload button enabled by default', () => {
+    setupHook();
+
+    render(<UploadBackgroundButton api={{ uploadImage: jest.fn() }} />);
+
+    const button = screen.getByRole('button', { name: /upload background/i });
+    expect(button).toBeEnabled();
+  });
+
+  it('disables the button and shows progress while uploading', () => {
+    setupHook({ status: 'uploading', progress: 42, isUploading: true });
+
+    render(<UploadBackgroundButton api={{ uploadImage: jest.fn() }} />);
+
+    const button = screen.getByRole('button', { name: /uploading/i });
+    expect(button).toBeDisabled();
+
+    const progress = screen.getByLabelText(/upload progress/i);
+    expect(progress).toHaveAttribute('value', '42');
+  });
+
+  it('announces successful uploads', () => {
+    setupHook({
+      status: 'success',
+      progress: 100,
+      lastUpload: { status: 'success', fileName: 'party.png' },
+    });
+
+    render(<UploadBackgroundButton api={{ uploadImage: jest.fn() }} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('party.png');
+  });
+
+  it('surfaces upload errors', () => {
+    const error = new Error('Upload failed');
+    setupHook({
+      status: 'error',
+      error,
+      lastUpload: { status: 'error', fileName: 'party.png', error },
+    });
+
+    render(<UploadBackgroundButton api={{ uploadImage: jest.fn() }} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Upload failed');
+  });
+
+  it('passes change events to the file upload hook', () => {
+    const handleInputChange = jest.fn();
+    setupHook({ handleInputChange });
+
+    render(<UploadBackgroundButton api={{ uploadImage: jest.fn() }} />);
+
+    const input = screen.getByLabelText(/upload background image/i);
+    fireEvent.change(input, { target: { files: [new File(['a'], 'demo.png', { type: 'image/png' })] } });
+
+    expect(handleInputChange).toHaveBeenCalled();
+  });
+});

--- a/frontend/hooks/__tests__/useFileUpload.test.jsx
+++ b/frontend/hooks/__tests__/useFileUpload.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import useFileUpload from '../useFileUpload.js';
+import { AppStateProvider, useAppState } from '../../context/AppStateContext.jsx';
+
+describe('useFileUpload', () => {
+  const wrapper = ({ children }) => <AppStateProvider>{children}</AppStateProvider>;
+
+  it('uploads a file and updates canvas state on success', async () => {
+    const api = {
+      uploadImage: jest.fn().mockResolvedValue({
+        image: {
+          id: 'img-1',
+          url: 'https://example.com/image.png',
+          thumbnailUrl: 'https://example.com/thumb.png',
+          width: 640,
+          height: 480,
+        },
+      }),
+    };
+
+    const { result } = renderHook(
+      () => {
+        const upload = useFileUpload({ api });
+        const appState = useAppState();
+        return { upload, appState };
+      },
+      { wrapper }
+    );
+
+    const file = new File(['hello'], 'party.png', { type: 'image/png' });
+
+    await act(async () => {
+      await result.current.upload.uploadFile(file);
+    });
+
+    expect(api.uploadImage).toHaveBeenCalledWith(file);
+    expect(result.current.upload.status).toBe('success');
+    expect(result.current.upload.progress).toBe(100);
+    expect(result.current.upload.lastUpload).toEqual(
+      expect.objectContaining({
+        status: 'success',
+        fileName: 'party.png',
+      })
+    );
+
+    expect(result.current.appState.imgState.has).toBe(true);
+    expect(result.current.appState.imgState.backendImageUrl).toBe(
+      'https://example.com/image.png'
+    );
+    expect(result.current.appState.imgState.backendThumbnailUrl).toBe(
+      'https://example.com/thumb.png'
+    );
+    expect(result.current.appState.imgState.natW).toBe(640);
+    expect(result.current.appState.imgState.natH).toBe(480);
+  });
+
+  it('records errors when uploads fail', async () => {
+    const error = new Error('Network down');
+    const api = {
+      uploadImage: jest.fn().mockRejectedValue(error),
+    };
+
+    const { result } = renderHook(() => useFileUpload({ api }), { wrapper });
+    const file = new File(['oops'], 'broken.png', { type: 'image/png' });
+
+    await act(async () => {
+      await expect(result.current.uploadFile(file)).rejects.toThrow('Network down');
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe(error);
+    expect(result.current.lastUpload).toEqual(
+      expect.objectContaining({
+        status: 'error',
+        fileName: 'broken.png',
+        error,
+      })
+    );
+  });
+});

--- a/frontend/hooks/useFileUpload.js
+++ b/frontend/hooks/useFileUpload.js
@@ -1,0 +1,186 @@
+import { useCallback } from 'react';
+import { useAppState } from '../context/AppStateContext.jsx';
+
+function normalizeUploadResult(response) {
+  if (!response) {
+    return null;
+  }
+
+  const image = response.image ?? response.asset ?? response;
+  const id =
+    image?.id ??
+    image?.imageId ??
+    response.imageId ??
+    response.id ??
+    null;
+  const url =
+    image?.url ??
+    image?.imageUrl ??
+    image?.fullUrl ??
+    response.url ??
+    response.imageUrl ??
+    null;
+  const thumbnailUrl =
+    image?.thumbnailUrl ??
+    image?.thumbnail ??
+    image?.thumbUrl ??
+    response.thumbnailUrl ??
+    response.thumbnail ??
+    null;
+  const width =
+    image?.width ??
+    image?.naturalWidth ??
+    image?.imageWidth ??
+    response.width ??
+    response.naturalWidth ??
+    null;
+  const height =
+    image?.height ??
+    image?.naturalHeight ??
+    image?.imageHeight ??
+    response.height ??
+    response.naturalHeight ??
+    null;
+
+  return {
+    id,
+    url,
+    thumbnailUrl,
+    width,
+    height,
+    original: response,
+  };
+}
+
+export default function useFileUpload({ api, onSuccess, onError } = {}) {
+  const {
+    fileUpload,
+    workSize,
+    startFileUpload,
+    setFileUploadProgress,
+    completeFileUpload,
+    failFileUpload,
+    updateImgState,
+  } = useAppState();
+
+  const applyImageToCanvas = useCallback(
+    (payload) => {
+      if (!payload) return;
+
+      const width = payload.width ?? workSize?.w ?? 0;
+      const height = payload.height ?? workSize?.h ?? 0;
+
+      updateImgState({
+        has: true,
+        backendImageId: payload.id ?? null,
+        backendImageUrl: payload.url ?? null,
+        backendThumbnailUrl: payload.thumbnailUrl ?? null,
+        natW: width ?? 0,
+        natH: height ?? 0,
+        cx: workSize?.w ? workSize.w / 2 : (width ?? 0) / 2,
+        cy: workSize?.h ? workSize.h / 2 : (height ?? 0) / 2,
+        scale: 1,
+        angle: 0,
+        shearX: 0,
+        shearY: 0,
+        signX: 1,
+        signY: 1,
+        flip: false,
+      });
+    },
+    [updateImgState, workSize]
+  );
+
+  const uploadFile = useCallback(
+    async (file) => {
+      if (!file) return null;
+
+      if (!api || typeof api.uploadImage !== 'function') {
+        const error = new Error('Upload service unavailable');
+        failFileUpload({ fileName: file.name ?? null, error });
+        throw error;
+      }
+
+      startFileUpload({ fileName: file.name ?? null });
+      setFileUploadProgress(5);
+
+      try {
+        const response = await api.uploadImage(file);
+        setFileUploadProgress(90);
+        const normalized = normalizeUploadResult(response);
+        completeFileUpload({ fileName: file.name ?? null, result: normalized });
+        if (normalized && (normalized.url || normalized.thumbnailUrl)) {
+          applyImageToCanvas(normalized);
+        }
+        if (typeof onSuccess === 'function') {
+          onSuccess(normalized);
+        }
+        return normalized;
+      } catch (cause) {
+        const error = cause instanceof Error ? cause : new Error(String(cause));
+        failFileUpload({ fileName: file.name ?? null, error });
+        if (typeof onError === 'function') {
+          onError(error);
+        }
+        throw error;
+      }
+    },
+    [
+      api,
+      applyImageToCanvas,
+      completeFileUpload,
+      failFileUpload,
+      onError,
+      onSuccess,
+      setFileUploadProgress,
+      startFileUpload,
+    ]
+  );
+
+  const handleFiles = useCallback(
+    async (files) => {
+      if (!files || files.length === 0) return null;
+      return uploadFile(files[0]);
+    },
+    [uploadFile]
+  );
+
+  const handleInputChange = useCallback(
+    async (event) => {
+      const input = event?.target ?? null;
+      const files = input?.files;
+      const file = files && files.length > 0 ? files[0] : null;
+      if (!file) return;
+
+      try {
+        await uploadFile(file);
+      } catch (_) {
+        // state updates triggered within uploadFile handle the failure case
+      } finally {
+        if (input) {
+          input.value = '';
+        }
+      }
+    },
+    [uploadFile]
+  );
+
+  const status = fileUpload?.status ?? 'idle';
+  const progress = fileUpload?.progress ?? 0;
+  const error = fileUpload?.error ?? null;
+  const lastUpload = fileUpload?.lastUpload ?? null;
+  const fileName = fileUpload?.fileName ?? null;
+
+  return {
+    fileUpload,
+    status,
+    progress,
+    error,
+    lastUpload,
+    fileName,
+    isUploading: status === 'uploading',
+    uploadFile,
+    handleFiles,
+    handleInputChange,
+  };
+}

--- a/frontend/pages/index.jsx
+++ b/frontend/pages/index.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
 import Topbar from '../components/Topbar.jsx';
 import AuthModal from '../components/AuthModal.jsx';
 import SidePanel from '../components/SidePanel.jsx';
@@ -9,6 +8,8 @@ import RotateOverlay from '../components/RotateOverlay.jsx';
 import PreviewModal from '../components/PreviewModal.jsx';
 import PurchaseModal from '../components/PurchaseModal.jsx';
 import Marketplace from '../components/Marketplace.jsx';
+import ImageCanvas from '../components/ImageCanvas.jsx';
+import UploadBackgroundButton from '../components/UploadBackgroundButton.jsx';
 import useAuth from '../hooks/useAuth.js';
 import useDesignOwnership from '../hooks/useDesignOwnership.js';
 
@@ -140,20 +141,9 @@ export default function MarketplacePage() {
 
         <main className="stage">
           <div className="wrap">
-            <div id="work" aria-label="Invitation stage (16:9)">
+            <ImageCanvas>
               <div id="vGuide" className="guide v" aria-hidden="true"></div>
               <div id="hGuide" className="guide h" aria-hidden="true"></div>
-
-                <div id="userBgWrap">
-                  <Image
-                    id="userBg"
-                    src="/placeholder.jpg"
-                    alt=""
-                    width={800}
-                    height={450}
-                    priority
-                  />
-                </div>
               <video id="fxVideo" autoPlay muted loop playsInline>
                 <source src="/Comp 1.webm" type="video/webm" />
               </video>
@@ -173,9 +163,8 @@ export default function MarketplacePage() {
                 <button id="rsvpMap" className="rsvp-btn primary">View Map</button>
               </div>
 
-              <button id="uploadBgBtn">Upload Background</button>
-              <input type="file" id="bgFileInput" accept="image/*" />
-            </div>
+              <UploadBackgroundButton api={auth.api} />
+            </ImageCanvas>
           </div>
         </main>
       </div>


### PR DESCRIPTION
## Summary
- add a fileUpload reducer slice with helper dispatchers on the app state context
- create a reusable file upload hook and button component wired to the API and image canvas
- expand Jest coverage for the new reducer, hook, component, and the marketplace page upload flow

## Testing
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68cdd277a078832a804378870cc3f848