### PR TITLE
Add role-aware navigation links and breadcrumbs

### DIFF
--- a/frontend/components/Topbar.jsx
+++ b/frontend/components/Topbar.jsx
@@ -1,23 +1,30 @@
 import { useMemo } from 'react';
 import { useAppState } from '../context/AppStateContext.jsx';
 import { resolveCapabilities, resolveRole } from '../utils/roleCapabilities.js';
+import { getRoleNavigationLinks } from '../utils/navigationLinks.js';
 
 export default function Topbar({
   onPreviewClick,
   onShareClick,
   onTogglePanel,
   panelOpen,
+  currentRole,
   roleCapabilities,
 }) {
   const { userRole } = useAppState();
 
   const { role: resolvedRole, canEdit } = useMemo(() => {
-    const fallbackRole = resolveRole(userRole);
+    const fallbackRole = resolveRole(currentRole ?? userRole);
     if (roleCapabilities && typeof roleCapabilities === 'object') {
       return resolveCapabilities(roleCapabilities, fallbackRole);
     }
     return resolveCapabilities({ role: fallbackRole }, fallbackRole);
-  }, [roleCapabilities, userRole]);
+  }, [currentRole, roleCapabilities, userRole]);
+
+  const navigationLinks = useMemo(
+    () => getRoleNavigationLinks(resolvedRole),
+    [resolvedRole]
+  );
 
   const readOnly = !canEdit;
   const editLockTitle = readOnly
@@ -32,6 +39,15 @@ export default function Topbar({
       data-editor-readonly={readOnly || undefined}
     >
       <div className="brand"> Celesia Animated Invitation</div>
+      <nav className="topbar-nav" aria-label="Primary">
+        <ul className="topbar-links">
+          {navigationLinks.map((link) => (
+            <li key={link.key || link.href} className="topbar-link-item">
+              <a href={link.href}>{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
       <div className="grow"></div>
 
       {/* editor controls hidden in viewer via .edit-only */}

--- a/frontend/components/__tests__/Breadcrumbs.test.jsx
+++ b/frontend/components/__tests__/Breadcrumbs.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import Breadcrumbs from '../Breadcrumbs.jsx';
 import { MockAppStateProvider } from '../../context/AppStateContext.jsx';
@@ -54,8 +54,36 @@ describe('Breadcrumbs', () => {
     const router = createMockRouter({ asPath: '/templates/birthday-party', pathname: '/templates/[slug]' });
     renderWithProviders({ router });
 
-    const link = screen.getByRole('link', { name: 'Birthday Party' });
-    expect(link).toHaveAttribute('href', '/templates/birthday-party');
-    expect(link).toHaveAttribute('aria-current', 'page');
+    const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    const links = within(nav).getAllByRole('link');
+
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveTextContent('Marketplace');
+    expect(links[0]).toHaveAttribute('href', '/');
+    expect(links[0]).not.toHaveAttribute('aria-current');
+
+    expect(links[1]).toHaveTextContent('Birthday Party');
+    expect(links[1]).toHaveAttribute('href', '/templates/birthday-party');
+    expect(links[1]).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('prepends admin role waypoints when history is seeded', () => {
+    renderWithProviders({
+      value: {
+        userRole: 'admin',
+        navigationHistory: [
+          { href: '/editor', label: 'Editor' },
+        ],
+      },
+    });
+
+    const nav = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    const links = within(nav).getAllByRole('link');
+
+    expect(links.map((link) => link.textContent)).toEqual([
+      'Marketplace',
+      'Admin Dashboard',
+      'Editor',
+    ]);
   });
 });

--- a/frontend/components/__tests__/Topbar.test.jsx
+++ b/frontend/components/__tests__/Topbar.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import Topbar from '../Topbar.jsx';
 import { MockAppStateProvider } from '../../context/AppStateContext.jsx';
 
@@ -60,6 +60,13 @@ describe('Topbar', () => {
     expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
     expect(screen.getByText('Slide 1/1')).toBeInTheDocument();
+
+    const nav = screen.getByRole('navigation', { name: 'Primary' });
+    const navLinks = within(nav).getAllByRole('link');
+    expect(navLinks.map((link) => link.textContent)).toEqual([
+      'Marketplace',
+      'Editor',
+    ]);
   });
 
   it('disables editing controls for consumer roles', () => {
@@ -84,5 +91,24 @@ describe('Topbar', () => {
     expect(onShareClick).toHaveBeenCalledTimes(1);
     expect(onPreviewClick).not.toHaveBeenCalled();
     expect(onTogglePanel).not.toHaveBeenCalled();
+
+    const nav = screen.getByRole('navigation', { name: 'Primary' });
+    const consumerLinks = within(nav).getAllByRole('link');
+    expect(consumerLinks).toHaveLength(1);
+    expect(consumerLinks[0]).toHaveTextContent('Marketplace');
+    expect(() => within(nav).getByRole('link', { name: 'Editor' })).toThrow();
+  });
+
+  it('surfaces admin-only navigation links when available', () => {
+    renderWithRole('admin');
+
+    const nav = screen.getByRole('navigation', { name: 'Primary' });
+    const links = within(nav).getAllByRole('link');
+
+    expect(links.map((link) => link.textContent)).toEqual([
+      'Marketplace',
+      'Editor',
+      'Admin Dashboard',
+    ]);
   });
 });

--- a/frontend/utils/navigationLinks.js
+++ b/frontend/utils/navigationLinks.js
@@ -1,0 +1,71 @@
+import { resolveRole } from './roleCapabilities.js';
+
+const BASE_NAV_LINKS = [
+  { key: 'marketplace', href: '/', label: 'Marketplace' },
+];
+
+const CREATOR_NAV_LINKS = [
+  { key: 'editor', href: '/editor', label: 'Editor' },
+];
+
+const ADMIN_NAV_LINKS = [
+  { key: 'admin-dashboard', href: '/admin/dashboard', label: 'Admin Dashboard' },
+];
+
+const ROLE_BREADCRUMB_WAYPOINTS = {
+  admin: [
+    { key: 'marketplace', href: '/', label: 'Marketplace' },
+    { key: 'admin-dashboard', href: '/admin/dashboard', label: 'Admin Dashboard' },
+  ],
+  creator: [
+    { key: 'marketplace', href: '/', label: 'Marketplace' },
+    { key: 'editor', href: '/editor', label: 'Editor' },
+  ],
+};
+
+function dedupeLinks(links) {
+  const seen = new Set();
+  const result = [];
+  for (const link of links) {
+    if (!link || typeof link.href !== 'string') {
+      continue;
+    }
+    const href = link.href.trim();
+    if (!href || seen.has(href)) {
+      continue;
+    }
+    seen.add(href);
+    result.push({
+      key: link.key ?? href,
+      href,
+      label: typeof link.label === 'string' && link.label.trim() ? link.label : href,
+    });
+  }
+  return result;
+}
+
+export function getRoleNavigationLinks(role) {
+  const resolvedRole = resolveRole(role);
+  const links = [...BASE_NAV_LINKS];
+
+  if (resolvedRole === 'creator' || resolvedRole === 'admin') {
+    links.push(...CREATOR_NAV_LINKS);
+  }
+
+  if (resolvedRole === 'admin') {
+    links.push(...ADMIN_NAV_LINKS);
+  }
+
+  return dedupeLinks(links);
+}
+
+export function getRoleBreadcrumbWaypoints(role) {
+  const resolvedRole = resolveRole(role);
+  if (resolvedRole === 'admin') {
+    return dedupeLinks(ROLE_BREADCRUMB_WAYPOINTS.admin);
+  }
+  if (resolvedRole === 'creator') {
+    return dedupeLinks(ROLE_BREADCRUMB_WAYPOINTS.creator);
+  }
+  return dedupeLinks(ROLE_BREADCRUMB_WAYPOINTS.creator.slice(0, 1));
+}


### PR DESCRIPTION
## Summary
- introduce shared role-aware navigation helpers
- render primary navigation links in the top bar based on the viewer role
- prepend role-specific waypoints to breadcrumbs and cover the new behavior with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceb2cf6d8c832a8b524ad5a6357c33