### PR TITLE
Add ownership filtering to marketplace listings

### DIFF
--- a/frontend/components/__tests__/Marketplace.test.jsx
+++ b/frontend/components/__tests__/Marketplace.test.jsx
@@ -277,8 +277,10 @@ describe('Marketplace', () => {
     await waitFor(() => expect(listMarketplace).toHaveBeenCalledTimes(2));
     expect(listMarketplace.mock.calls[1][0]).toEqual({
       role: 'admin',
-      category: 'owned-by-42-admin',
+      category: undefined,
       search: undefined,
+      mine: true,
+      ownerId: '42-admin',
     });
     expect(myDesignsTab).toHaveAttribute('aria-selected', 'true');
   });

--- a/frontend/services/api-client.js
+++ b/frontend/services/api-client.js
@@ -383,7 +383,7 @@ class APIClient {
   // Marketplace endpoints
   async listMarketplace(filters = {}) {
     const params = {};
-    const { role, category, search } = filters || {};
+    const { role, category, search, ownerId, mine } = filters || {};
 
     if (typeof role === 'string' && role.trim()) {
       params.role = role.trim().toLowerCase();
@@ -395,6 +395,20 @@ class APIClient {
 
     if (typeof search === 'string' && search.trim()) {
       params.search = search.trim();
+    }
+
+    if (ownerId !== undefined && ownerId !== null) {
+      const owner = String(ownerId).trim();
+      if (owner) {
+        params.ownerId = owner;
+      }
+    }
+
+    const normalizedMine = typeof mine === 'string'
+      ? ['1', 'true', 'yes', 'y'].includes(mine.trim().toLowerCase())
+      : Boolean(mine);
+    if (normalizedMine) {
+      params.mine = 'true';
     }
 
     return this.get('/api/marketplace', params);

--- a/server/__tests__/marketplace.test.js
+++ b/server/__tests__/marketplace.test.js
@@ -48,3 +48,23 @@ test('admin role includes visibility info and conversion rates', async () => {
 test('requesting an unsupported role rejects', async () => {
   await assert.rejects(() => getMarketplaceDesigns({ role: 'guest' }));
 });
+
+test('ownership filters restrict marketplace listings to matching designers', async () => {
+  const ownerResult = await getMarketplaceDesigns({ role: 'admin', ownerId: 'demo' });
+  assert.equal(ownerResult.role, 'admin');
+  assert.deepEqual(
+    ownerResult.data.map((entry) => entry.id),
+    ['1', '2']
+  );
+
+  const mineResult = await getMarketplaceDesigns({
+    role: 'admin',
+    mine: true,
+    requestingUserId: 'studio-omega',
+  });
+  assert.equal(mineResult.role, 'admin');
+  assert.deepEqual(
+    mineResult.data.map((entry) => entry.id),
+    ['3']
+  );
+});

--- a/server/index.js
+++ b/server/index.js
@@ -1066,10 +1066,20 @@ const server = http.createServer(async (req, res) => {
         return;
       }
 
+      const ownerIdParam = urlObj.searchParams.get('ownerId');
+      const ownerId = ownerIdParam ? ownerIdParam.trim() : '';
+      const mineParam = urlObj.searchParams.get('mine');
+      const mineRequested = typeof mineParam === 'string' && mineParam.trim()
+        ? ['1', 'true', 'yes', 'y'].includes(mineParam.trim().toLowerCase())
+        : false;
+
       const payload = await getMarketplaceDesigns({
         role: effectiveRole,
         category: category || undefined,
-        search: search || undefined
+        search: search || undefined,
+        ownerId: ownerId || undefined,
+        mine: mineRequested,
+        requestingUserId: authUser.id,
       });
 
       res.writeHead(200, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
- add ownership-aware filtering to the marketplace data store and API handler
- update the API client and marketplace component to request owned designs when the My Designs tab is active
- expand server and frontend tests to cover the new ownership filter behaviour

## Testing
- JWT_SECRET=test-secret node --test server/__tests__/*.test.js
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68ceccf9d02c832a912a8034322d3265