### PR TITLE
Show admin marketplace status badges

### DIFF
--- a/frontend/components/Marketplace.jsx
+++ b/frontend/components/Marketplace.jsx
@@ -413,6 +413,12 @@ export default function Marketplace({ isOpen, onSkipToEditor }) {
             const flagEntries = extractFlagEntries(listing?.flags);
             const conversionRateLabel = formatConversionRate(listing?.conversionRate);
             const listingIsPublished = isListingPublished(listing);
+            const rawStatus = typeof listing?.status === 'string' ? listing.status.trim() : '';
+            const normalizedStatus = rawStatus.toLowerCase();
+            const statusLabel = normalizedStatus
+              ? normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1)
+              : null;
+            const statusBadgeTestId = `marketplace-status-badge-${cardId}`;
 
             return (
               <article
@@ -420,7 +426,20 @@ export default function Marketplace({ isOpen, onSkipToEditor }) {
                 className="marketplace-card"
                 data-testid={`marketplace-card-${cardId}`}
               >
-                <h3>{listing?.title || `Design ${cardId}`}</h3>
+                <h3 className="marketplace-card-title">
+                  <span className="marketplace-card-title-text">
+                    {listing?.title || `Design ${cardId}`}
+                  </span>
+                  {isAdmin && statusLabel ? (
+                    <span
+                      className={`marketplace-status-badge status-${normalizedStatus}`}
+                      data-testid={statusBadgeTestId}
+                      aria-label={`Status: ${statusLabel}`}
+                    >
+                      {statusLabel}
+                    </span>
+                  ) : null}
+                </h3>
                 {designerName ? (
                   <p className="marketplace-designer">{designerName}</p>
                 ) : null}

--- a/frontend/components/__tests__/Marketplace.test.jsx
+++ b/frontend/components/__tests__/Marketplace.test.jsx
@@ -274,6 +274,9 @@ describe('Marketplace', () => {
     expect(adminExtras).toHaveTextContent('Conversion Rate: 50%');
     expect(adminExtras).toHaveTextContent('managedBy: ops-team');
 
+    const statusBadge = await screen.findByTestId('marketplace-status-badge-1');
+    expect(statusBadge).toHaveTextContent('Draft');
+
     const manageButton = within(adminExtras).getByRole('button', { name: /manage listing/i });
     const publishButton = within(adminExtras).getByRole('button', { name: /publish listing/i });
     const deleteButton = within(adminExtras).getByRole('button', { name: /delete listing/i });
@@ -328,6 +331,34 @@ describe('Marketplace', () => {
 
     expect(publishButton).toBeDisabled();
     expect(publishMarketplaceListing).not.toHaveBeenCalled();
+
+    await waitFor(() => expect(listMarketplace).toHaveBeenCalledTimes(1));
+  });
+
+  it('renders status badges for draft and published admin listings', async () => {
+    const adminListings = [
+      {
+        id: '1',
+        title: 'Draft Template',
+        status: 'draft',
+        designer: { displayName: 'Design Studio' },
+      },
+      {
+        id: '2',
+        title: 'Published Template',
+        status: 'published',
+        designer: { displayName: 'Launch Team' },
+      },
+    ];
+    const { listMarketplace } = mockAuth({ role: 'admin', listings: adminListings });
+
+    render(<Marketplace isOpen onSkipToEditor={jest.fn()} />);
+
+    const draftBadge = await screen.findByTestId('marketplace-status-badge-1');
+    const publishedBadge = await screen.findByTestId('marketplace-status-badge-2');
+
+    expect(draftBadge).toHaveTextContent('Draft');
+    expect(publishedBadge).toHaveTextContent('Published');
 
     await waitFor(() => expect(listMarketplace).toHaveBeenCalledTimes(1));
   });

--- a/frontend/styles/styles.css
+++ b/frontend/styles/styles.css
@@ -2280,6 +2280,54 @@ body.resizing {
   margin-top: 24px;
 }
 
+.marketplace-card {
+  background: rgba(11, 22, 48, 0.85);
+  border: 1px solid #26334f;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.marketplace-card-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.marketplace-card-title-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.marketplace-status-badge {
+  background: #26334f;
+  color: #fff;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  text-transform: capitalize;
+}
+
+.marketplace-status-badge.status-published {
+  background: #1f7a53;
+}
+
+.marketplace-status-badge.status-draft {
+  background: #b8860b;
+}
+
+.marketplace-status-badge.status-archived {
+  background: #5c667a;
+}
+
 .marketplace-layout {
   display: flex;
   gap: 24px;

--- a/server/__tests__/marketplace.test.js
+++ b/server/__tests__/marketplace.test.js
@@ -43,6 +43,7 @@ test('admin role includes visibility info and conversion rates', async () => {
   assert.ok(entry.visibility);
   assert.equal(entry.visibility.consumer, true);
   assert.equal(entry.conversionRate, 0.5);
+  assert.equal(entry.status, 'published');
 });
 
 test('requesting an unsupported role rejects', async () => {

--- a/server/designs-store.js
+++ b/server/designs-store.js
@@ -98,6 +98,9 @@ function shapeMarketplaceRecord(design, role, conversionLookup) {
     const rate = conversionLookup?.get(String(design.id));
     base.conversionRate = typeof rate === 'number' && Number.isFinite(rate) ? rate : 0;
     base.managedByAdminId = design.managedByAdminId ? String(design.managedByAdminId) : null;
+    const normalizedStatus =
+      typeof design.status === 'string' ? design.status.trim().toLowerCase() : '';
+    base.status = normalizedStatus || 'draft';
   }
 
   return base;


### PR DESCRIPTION
## Summary
- expose normalized status values on admin marketplace records
- render admin-only status badges on marketplace cards with supporting styles
- extend backend and frontend tests to cover status payloads and badge labels

## Testing
- node --test server/__tests__/*.test.js
- npm --prefix frontend test -- --runTestsByPath components/__tests__/Marketplace.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68ced743c8ec832a85155635d003dfe9