### PR TITLE
Use stateful authentication flag in useAuth

### DIFF
--- a/frontend/hooks/__tests__/useAuth.test.jsx
+++ b/frontend/hooks/__tests__/useAuth.test.jsx
@@ -1,0 +1,46 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { AppStateProvider } from '../../context/AppStateContext.jsx';
+import useAuth from '../useAuth.js';
+import useApiClient from '../useApiClient.js';
+
+jest.mock('../useApiClient.js', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const wrapper = ({ children }) => <AppStateProvider>{children}</AppStateProvider>;
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports unauthenticated until the client initialization effect completes', async () => {
+    const getUser = jest.fn().mockReturnValue({ id: 'demo-user', role: 'creator' });
+    const api = {
+      isAuthenticated: jest.fn().mockReturnValue(true),
+      getUser,
+      login: jest.fn(),
+      logout: jest.fn(),
+      getCurrentUser: jest.fn(),
+    };
+
+    useApiClient.mockReturnValue(api);
+
+    const states = [];
+    const { result } = renderHook(() => {
+      const value = useAuth();
+      states.push(value.isAuthenticated);
+      return value;
+    }, { wrapper });
+
+    expect(states[0]).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    expect(api.isAuthenticated).toHaveBeenCalled();
+    expect(getUser).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- manage the `isAuthenticated` flag inside `useAuth` with React state and synchronize it during login, logout, and refresh operations
- hydrate authentication status from the client-only initialization effect while keeping related app state in sync
- add a unit test that proves the hook stays unauthenticated until the client initialization runs

## Testing
- npm --prefix frontend test -- --runTestsByPath hooks/__tests__/useAuth.test.jsx pages/__tests__/index.test.jsx components/__tests__/Marketplace.test.jsx hooks/__tests__/useDesignOwnership.test.jsx --verbose

------
https://chatgpt.com/codex/tasks/task_e_68cee4c45e28832a8810e4ffe14d8789