### PR TITLE
Maintain auth state when cached profile is missing

### DIFF
--- a/frontend/context/AuthContext.jsx
+++ b/frontend/context/AuthContext.jsx
@@ -151,11 +151,16 @@ export function AuthProvider({ children, apiClient = null }) {
       });
     };
 
-    const clearUserState = () => {
+    const clearUserProfileState = () => {
       setUser(null);
       resetUserRole();
+    };
+
+    const resetAppState = () => {
+      clearUserProfileState();
       resetDesignOwnership();
       setCurrentDesignId(null);
+      pendingUserRefresh.current = false;
     };
 
     try {
@@ -168,31 +173,26 @@ export function AuthProvider({ children, apiClient = null }) {
             setUser(sessionUser);
             applyUserRole(sessionUser);
           } else if (!user) {
-            clearUserState();
+            clearUserProfileState();
             queueRefreshUser();
           }
         } catch (_) {
           if (!user) {
-            clearUserState();
+            clearUserProfileState();
             queueRefreshUser();
           }
         }
       } else {
         shouldResetAppState = true;
         setIsAuthenticated(false);
-        setUser(null);
       }
     } catch (_) {
       shouldResetAppState = true;
       setIsAuthenticated(false);
-      setUser(null);
     }
 
     if (shouldResetAppState) {
-      resetUserRole();
-      resetDesignOwnership();
-      setCurrentDesignId(null);
-      pendingUserRefresh.current = false;
+      resetAppState();
     }
 
     setIsInitialized(true);


### PR DESCRIPTION
## Summary
- keep AuthProvider authenticated when local session data lacks a cached user while only clearing the profile state and queuing a refresh
- queue refreshes without wiping broader app state and centralize reset logic for invalid tokens
- cover missing cached user scenarios in useAuth tests, including ensuring other app context resets are not triggered

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cefff1d7b0832abc8f2759d356e27b