### PR TITLE
Implement worker marketplace routing with shared helpers

### DIFF
--- a/server/designs-store.js
+++ b/server/designs-store.js
@@ -4,8 +4,7 @@
 
 import { designs, designOwners } from './database.js';
 import { getConversionRates } from './analytics-store.js';
-
-const MARKETPLACE_ROLES = new Set(['creator', 'consumer', 'admin']);
+import { MARKETPLACE_ROLES } from '../shared/marketplace.js';
 
 function toDisplayName(userId) {
   const value = String(userId || '').trim();

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ import {
   updateWebmFile
 } from './webm-store.js';
 import { getNavigationState, saveNavigationState } from './navigation-state-store.js';
+import { isAdminRole, resolveMarketplaceRole, MARKETPLACE_ROLES } from '../shared/marketplace.js';
 
 const port = process.env.PORT || 3001;
 
@@ -56,25 +57,6 @@ function rateLimit(req, res) {
 const forbidden = ['admin', 'administrator', 'root', 'superuser'];
 const users = new Map();
 let nextUserId = 1;
-
-function normalizeRole(role = '') {
-  return String(role || '').trim().toLowerCase();
-}
-
-function isAdminRole(role = '') {
-  return normalizeRole(role) === 'admin';
-}
-
-const MARKETPLACE_ROLE_ALIASES = new Map([
-  ['user', 'consumer']
-]);
-const MARKETPLACE_ROLES = new Set(['creator', 'consumer', 'admin']);
-
-function resolveMarketplaceRole(role = '') {
-  const normalized = normalizeRole(role);
-  if (!normalized) return '';
-  return MARKETPLACE_ROLE_ALIASES.get(normalized) || normalized;
-}
 
 function getStoredUser(userId) {
   return users.get(String(userId));

--- a/shared/marketplace.js
+++ b/shared/marketplace.js
@@ -1,0 +1,19 @@
+const MARKETPLACE_ROLE_ALIASES = new Map([
+  ['user', 'consumer']
+]);
+
+export const MARKETPLACE_ROLES = new Set(['creator', 'consumer', 'admin']);
+
+function normalizeRole(role = '') {
+  return String(role || '').trim().toLowerCase();
+}
+
+export function resolveMarketplaceRole(role = '') {
+  const normalized = normalizeRole(role);
+  if (!normalized) return '';
+  return MARKETPLACE_ROLE_ALIASES.get(normalized) || normalized;
+}
+
+export function isAdminRole(role = '') {
+  return normalizeRole(role) === 'admin';
+}

--- a/worker/__tests__/marketplace.test.js
+++ b/worker/__tests__/marketplace.test.js
@@ -1,0 +1,115 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { recordView, recordConversion } from '../../server/analytics-store.js';
+
+const workerModule = await import('../index.js');
+const worker = workerModule.default ?? workerModule;
+
+function buildHeaders(overrides = {}) {
+  return {
+    'X-User-Id': 'user-default',
+    'X-User-Role': 'user',
+    ...overrides
+  };
+}
+
+async function fetchMarketplace(path, { headers } = {}) {
+  const request = new Request(`https://example.com${path}`, {
+    method: 'GET',
+    headers: headers ?? buildHeaders()
+  });
+  const response = await worker.fetch(request, {}, {});
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = null;
+  }
+  return { response, body };
+}
+
+test('consumer alias resolves to consumer marketplace listings', async () => {
+  const { response, body } = await fetchMarketplace('/api/marketplace', {
+    headers: buildHeaders({ 'X-User-Id': 'consumer-user', 'X-User-Role': 'user' })
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(body.role, 'consumer');
+  const ids = body.data.map((entry) => entry.id);
+  assert.ok(ids.includes('1'));
+  assert.ok(!ids.includes('2'));
+  assert.ok(ids.includes('3'));
+});
+
+test('creator role exposes creator listings and flags', async () => {
+  const { response, body } = await fetchMarketplace('/api/marketplace', {
+    headers: buildHeaders({ 'X-User-Role': 'creator' })
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(body.role, 'creator');
+  const ids = body.data.map((entry) => entry.id);
+  assert.ok(ids.includes('2'));
+  assert.ok(!ids.includes('3'));
+  const creatorListing = body.data.find((entry) => entry.id === '2');
+  assert.ok(creatorListing?.flags);
+  assert.ok(Object.prototype.hasOwnProperty.call(creatorListing.flags, 'isAdminTemplate'));
+});
+
+test('admin role returns visibility and conversion insights', async () => {
+  recordView('1');
+  recordView('1');
+  recordConversion('1');
+
+  const { response, body } = await fetchMarketplace('/api/marketplace', {
+    headers: buildHeaders({ 'X-User-Role': 'admin', 'X-User-Id': 'admin-user' })
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(body.role, 'admin');
+  const entry = body.data.find((item) => item.id === '1');
+  assert.ok(entry);
+  assert.ok(entry.visibility);
+  assert.equal(entry.visibility.consumer, true);
+  assert.equal(entry.conversionRate, 0.5);
+});
+
+test('unsupported roles are rejected', async () => {
+  const { response, body } = await fetchMarketplace('/api/marketplace', {
+    headers: buildHeaders({ 'X-User-Role': 'guest' })
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(body?.error, 'Unsupported role');
+});
+
+test('non-admin callers cannot override their marketplace role', async () => {
+  const { response, body } = await fetchMarketplace('/api/marketplace?role=admin', {
+    headers: buildHeaders({ 'X-User-Role': 'creator' })
+  });
+
+  assert.equal(response.status, 403);
+  assert.equal(body?.error, 'Forbidden role override');
+});
+
+test('ownership filters limit marketplace payloads', async () => {
+  const ownerResponse = await fetchMarketplace('/api/marketplace?ownerId=demo', {
+    headers: buildHeaders({ 'X-User-Role': 'admin' })
+  });
+  assert.equal(ownerResponse.response.status, 200);
+  assert.deepEqual(
+    ownerResponse.body.data.map((entry) => entry.id),
+    ['1', '2']
+  );
+
+  const mineResponse = await fetchMarketplace('/api/marketplace?mine=1', {
+    headers: buildHeaders({ 'X-User-Role': 'admin', 'X-User-Id': 'studio-omega' })
+  });
+  assert.equal(mineResponse.response.status, 200);
+  assert.deepEqual(
+    mineResponse.body.data.map((entry) => entry.id),
+    ['3']
+  );
+});

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,89 @@
+import { getMarketplaceDesigns } from '../server/designs-store.js';
+import { resolveMarketplaceRole, isAdminRole, MARKETPLACE_ROLES } from '../shared/marketplace.js';
+
+function jsonResponse(status, payload) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+function getRequestUser(request) {
+  const headers = request.headers;
+  const role = headers.get('x-user-role') || '';
+  const userId = headers.get('x-user-id') || '';
+  return {
+    id: typeof userId === 'string' ? userId.trim() : '',
+    role: typeof role === 'string' ? role.trim() : ''
+  };
+}
+
+function parseMine(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return ['1', 'true', 'yes', 'y'].includes(trimmed.toLowerCase());
+}
+
+async function handleMarketplaceRequest(request) {
+  const url = new URL(request.url);
+  const user = getRequestUser(request);
+
+  const defaultRole = resolveMarketplaceRole(user.role) || 'consumer';
+  if (!MARKETPLACE_ROLES.has(defaultRole)) {
+    return jsonResponse(400, { error: 'Unsupported role' });
+  }
+
+  let effectiveRole = defaultRole;
+  const requestedRoleParam = url.searchParams.get('role');
+  if (requestedRoleParam !== null) {
+    const requestedRole = resolveMarketplaceRole(requestedRoleParam);
+    if (!MARKETPLACE_ROLES.has(requestedRole)) {
+      return jsonResponse(400, { error: 'Unsupported role' });
+    }
+    if (!isAdminRole(defaultRole) && requestedRole !== defaultRole) {
+      return jsonResponse(403, { error: 'Forbidden role override' });
+    }
+    effectiveRole = requestedRole;
+  }
+
+  const categoryParam = url.searchParams.get('category');
+  const category = categoryParam ? categoryParam.trim() : '';
+  if (category && !/^[\w-]+$/.test(category)) {
+    return jsonResponse(400, { error: 'Invalid category filter' });
+  }
+
+  const searchParam = url.searchParams.get('search');
+  const search = searchParam ? searchParam.trim() : '';
+  if (search.length > 100) {
+    return jsonResponse(400, { error: 'Search query too long' });
+  }
+
+  const ownerIdParam = url.searchParams.get('ownerId');
+  const ownerId = ownerIdParam ? ownerIdParam.trim() : '';
+  const mineParam = url.searchParams.get('mine');
+  const mineRequested = parseMine(mineParam);
+
+  const payload = await getMarketplaceDesigns({
+    role: effectiveRole,
+    category: category || undefined,
+    search: search || undefined,
+    ownerId: ownerId || undefined,
+    mine: mineRequested,
+    requestingUserId: user.id || undefined
+  });
+
+  return jsonResponse(200, payload);
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.method === 'GET' && url.pathname === '/api/marketplace') {
+      return handleMarketplaceRequest(request);
+    }
+    return new Response('Not Found', { status: 404 });
+  }
+};
+
+export { handleMarketplaceRequest };


### PR DESCRIPTION
## Summary
- extract marketplace role helpers into a shared module for reuse by the Node server and worker
- add a Cloudflare worker fetch handler for GET /api/marketplace that mirrors server validation and filtering logic
- add worker tests covering consumer, creator, admin, invalid role, override, and ownership filter scenarios

## Testing
- node --test worker/__tests__/marketplace.test.js
- node --test server/__tests__/marketplace.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf1047aadc832aa62726cef28d8d30