### PR TITLE
Normalize API client request URLs

### DIFF
--- a/frontend/test/services/api-client.node.test.js
+++ b/frontend/test/services/api-client.node.test.js
@@ -42,3 +42,46 @@ describe('APIClient.saveToken in non-browser environments', () => {
     expect(client.token).toBe('token-123');
   });
 });
+
+describe('APIClient marketplace endpoint resolution', () => {
+  const createFetchSpy = () => jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'application/json' },
+    json: async () => ({ items: [] }),
+    text: async () => ''
+  });
+
+  test('absolute base without /api yields /api/marketplace path', async () => {
+    const fetchSpy = createFetchSpy();
+    const client = new APIClient('https://example.com', fetchSpy);
+
+    await client.listMarketplace();
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/api/marketplace', expect.objectContaining({
+      method: 'GET'
+    }));
+  });
+
+  test('absolute base ending in /api avoids duplication', async () => {
+    const fetchSpy = createFetchSpy();
+    const client = new APIClient('https://example.com/api', fetchSpy);
+
+    await client.listMarketplace();
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/api/marketplace', expect.objectContaining({
+      method: 'GET'
+    }));
+  });
+
+  test('relative /api base keeps single /api prefix', async () => {
+    const fetchSpy = createFetchSpy();
+    const client = new APIClient('/api', fetchSpy);
+
+    await client.listMarketplace();
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/marketplace', expect.objectContaining({
+      method: 'GET'
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable _buildRequestUrl helper that normalizes slashes and avoids duplicate /api segments
- update listMarketplace to rely on the helper so marketplace requests resolve correctly across base URL variants
- extend the node API client tests with fetch spies covering several base URL combinations

## Testing
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68cf229c12dc832aa65dabf23f2fbb96