### PR TITLE
Fix marketplace API endpoint path

### DIFF
--- a/frontend/services/api-client.js
+++ b/frontend/services/api-client.js
@@ -466,9 +466,9 @@ async listMarketplace(filters = {}) {
     : Boolean(mine);
   if (normalizedMine) params.mine = 'true';
 
-  // NOTE: endpoint has NO /api prefix; request() + _buildRequestUrl() will add it if baseURL ends with /api
+  // Always target the API namespace so base URLs without /api still reach the marketplace route.
   const qs = new URLSearchParams(params).toString();
-  const endpoint = '/marketplace';
+  const endpoint = '/api/marketplace';
   const url = qs ? `${endpoint}?${qs}` : endpoint;
 
   return this.request(url, { method: 'GET' });

--- a/frontend/test/services/api-client.node.test.js
+++ b/frontend/test/services/api-client.node.test.js
@@ -52,35 +52,18 @@ describe('APIClient marketplace endpoint resolution', () => {
     text: async () => ''
   });
 
-  test('absolute base without /api yields /api/marketplace path', async () => {
+  test.each([
+    ['absolute base without /api yields /api/marketplace path', 'https://example.com', 'https://example.com/api/marketplace'],
+    ['absolute base ending in /api avoids duplication', 'https://example.com/api', 'https://example.com/api/marketplace'],
+    ['absolute base with trailing slash still gains api prefix', 'https://example.com/', 'https://example.com/api/marketplace'],
+    ['relative /api base keeps single /api prefix', '/api', '/api/marketplace']
+  ])('%s', async (_label, baseUrl, expectedUrl) => {
     const fetchSpy = createFetchSpy();
-    const client = new APIClient('https://example.com', fetchSpy);
+    const client = new APIClient(baseUrl, fetchSpy);
 
     await client.listMarketplace();
 
-    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/api/marketplace', expect.objectContaining({
-      method: 'GET'
-    }));
-  });
-
-  test('absolute base ending in /api avoids duplication', async () => {
-    const fetchSpy = createFetchSpy();
-    const client = new APIClient('https://example.com/api', fetchSpy);
-
-    await client.listMarketplace();
-
-    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/api/marketplace', expect.objectContaining({
-      method: 'GET'
-    }));
-  });
-
-  test('relative /api base keeps single /api prefix', async () => {
-    const fetchSpy = createFetchSpy();
-    const client = new APIClient('/api', fetchSpy);
-
-    await client.listMarketplace();
-
-    expect(fetchSpy).toHaveBeenCalledWith('/api/marketplace', expect.objectContaining({
+    expect(fetchSpy).toHaveBeenCalledWith(expectedUrl, expect.objectContaining({
       method: 'GET'
     }));
   });


### PR DESCRIPTION
## Summary
- ensure the marketplace client always targets `/api/marketplace`, even when the configured base URL lacks the `/api` suffix
- refactor the marketplace endpoint tests to cover several base URL shapes, including trailing slashes

## Testing
- npm --prefix frontend test -- frontend/test/services/api-client.node.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf3663e8c8832ab89651064e50a8b7